### PR TITLE
Add second accuracy to metrics

### DIFF
--- a/packages/metrics/modules/observe/observe.js
+++ b/packages/metrics/modules/observe/observe.js
@@ -15,20 +15,23 @@ const sortLabels = unsortedLabels => {
 const endMeasurmentFrom = start => {
   const [seconds, nanoseconds] = process.hrtime(start);
 
-  // NOTE: Math to get a millisecond based duration which is a good
-  // default for Prometheus metrics.
-  return Math.round((seconds * NS_PER_SEC + nanoseconds) / NS_PER_MS);
+  return {
+    durationMs: Math.round((seconds * NS_PER_SEC + nanoseconds) / NS_PER_MS),
+    durationS: seconds,
+  };
 };
 
 const createObserver = options => {
   const metrics = createMetricTypes(options);
 
   return (start, options) => {
-    const durationMs = endMeasurmentFrom(start);
+    const { durationMs, durationS } = endMeasurmentFrom(start);
     const labels = sortLabels(options.labels);
 
-    metrics.percentiles.observe(labels, durationMs);
-    metrics.buckets.observe(labels, durationMs);
+    metrics.percentilesInMilliseconds.observe(labels, durationMs);
+    metrics.percentilesInSeconds.observe(labels, durationS);
+    metrics.bucketsInMilliseconds.observe(labels, durationMs);
+    metrics.bucketsInSeconds.observe(labels, durationS);
   };
 };
 

--- a/packages/metrics/modules/types/types.js
+++ b/packages/metrics/modules/types/types.js
@@ -2,19 +2,31 @@ const { Prometheus } = require('../client');
 
 const defaultLabels = ['path', 'status_code', 'method'];
 
+/**
+ * NOTE:
+ *    Prometheus has settled on second accuracy. Promster
+ *    started out with milliseconds. To not create a breaking
+ *    change now both types are recorded.
+ */
 const createMetricTypes = (options = { labels: [] }) => {
   const metrics = {
     up: new Prometheus.Gauge({
       name: 'up',
       help: '1 = up, 0 = not up',
     }),
-    percentiles: new Prometheus.Summary({
+    percentilesInMilliseconds: new Prometheus.Summary({
       name: 'http_request_duration_percentiles_milliseconds',
       help: 'The HTTP request latencies in milliseconds.',
       labelNames: defaultLabels.concat(options.labels).sort(),
       percentiles: options.percentiles || [0.5, 0.9, 0.95, 0.98, 0.99],
     }),
-    buckets: new Prometheus.Histogram({
+    percentilesInSeconds: new Prometheus.Summary({
+      name: 'http_request_duration_percentiles_seconds',
+      help: 'The HTTP request latencies in seconds.',
+      labelNames: defaultLabels.concat(options.labels).sort(),
+      percentiles: options.percentiles || [0.5, 0.9, 0.95, 0.98, 0.99],
+    }),
+    bucketsInMilliseconds: new Prometheus.Histogram({
       name: 'http_request_duration_buckets_milliseconds',
       help: 'The HTTP request latencies in milliseconds.',
       labelNames: defaultLabels.concat(options.labels).sort(),
@@ -26,10 +38,17 @@ const createMetricTypes = (options = { labels: [] }) => {
         800,
         1000,
         1500,
+        2000,
         3000,
         5000,
         10000,
       ],
+    }),
+    bucketsInSeconds: new Prometheus.Histogram({
+      name: 'http_request_duration_buckets_seconds',
+      help: 'The HTTP request latencies in seconds.',
+      labelNames: defaultLabels.concat(options.labels).sort(),
+      buckets: options.buckets || [0.05, 0.1, 0.3, 0.5, 0.8, 1, 1.5, 2, 3, 10],
     }),
   };
 


### PR DESCRIPTION
Milliseconds is deprecated (kind of) and will be removed in a breaking release.