### PR TITLE
feat(request-observer): change seconds duration precision to float

### DIFF
--- a/packages/metrics/modules/create-request-observer/create-request-observer.js
+++ b/packages/metrics/modules/create-request-observer/create-request-observer.js
@@ -17,7 +17,7 @@ const endMeasurmentFrom = start => {
 
   return {
     durationMs: Math.round((seconds * NS_PER_SEC + nanoseconds) / NS_PER_MS),
-    durationS: seconds,
+    durationS: (seconds * NS_PER_SEC + nanoseconds) / NS_PER_SEC,
   };
 };
 


### PR DESCRIPTION
Fixes #26 by allowing seconds as float, in order to respect [Prometheus Best Practices](https://prometheus.io/docs/practices/naming/#base-units) and have a good enough precision for calculations.