### PR TITLE
fix(server): add rejection when server creation fails

### DIFF
--- a/packages/server/modules/server/server.js
+++ b/packages/server/modules/server/server.js
@@ -2,13 +2,16 @@ const http = require('http');
 const { getSummary, getContentType } = require('@promster/metrics');
 
 const createServer = (options = { port: 7788, hostname: '0.0.0.0' }) => {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     const server = http.createServer((req, res) => {
       res.writeHead(200, 'OK', { 'content-type': getContentType() });
       res.end(getSummary());
     });
 
-    server.listen(options.port, options.host, () => resolve(server));
+    server.listen(options.port, options.host, error => {
+      if (error) reject(error);
+      else resolve(server);
+    });
   });
 };
 


### PR DESCRIPTION
#### Summary

The `listen` call passes an `error` to the callback we should reject the promise with if it's set.