### PR TITLE
fix missing attributes when register plugin

### DIFF
--- a/packages/hapi/modules/index.js
+++ b/packages/hapi/modules/index.js
@@ -23,3 +23,6 @@ exports.getContentType = getContentType;
 exports.Prometheus = Prometheus;
 exports.defaultRegister = defaultRegister;
 exports.defaultNormalizers = defaultNormalizers;
+exports.instrument = (server, options) => {
+  server.register(createPlugin(options))
+}

--- a/packages/hapi/modules/plugin/plugin.js
+++ b/packages/hapi/modules/plugin/plugin.js
@@ -69,8 +69,7 @@ const createPlugin = ({ options } = {}) => {
   };
 
   plugin.register.attributes = {
-    name: 'epimetheus',
-    version: '1.0.0'
+    pkg: pkg
   }
 
   return plugin;

--- a/packages/hapi/modules/plugin/plugin.js
+++ b/packages/hapi/modules/plugin/plugin.js
@@ -37,7 +37,7 @@ const createPlugin = ({ options } = {}) => {
   const plugin = {
     name: pkg.name,
     version: pkg.version,
-    register(server) {
+    register(server, o, done) {
       server.ext('onRequest', (request, h) => {
         request.promster = { start: process.hrtime() };
         return h.continue;
@@ -63,8 +63,15 @@ const createPlugin = ({ options } = {}) => {
 
       server.decorate('server', 'Prometheus', Prometheus);
       server.decorate('server', 'recordRequest', recordRequest);
+
+      return done();
     },
   };
+
+  plugin.register.attributes = {
+    name: 'epimetheus',
+    version: '1.0.0'
+  }
 
   return plugin;
 };


### PR DESCRIPTION
fix missing attributes error when register plugin with HapiJS: ` "[1] "attributes" is required"` BY:
- add/export instrument for plugin registration

e.g.
const server = new hapi.Server();
const promster = require('@promster/hapi');
promster.instrument(server, options);

related to issue: https://github.com/tdeekens/promster/issues/131