### PR TITLE
feat(fatify): add plugin

### DIFF
--- a/packages/fastify/modules/index.js
+++ b/packages/fastify/modules/index.js
@@ -1,0 +1,25 @@
+const { version } = require('../package.json');
+const {
+  promsterPlugin,
+  getRequestRecorder,
+  signalIsUp,
+  signalIsNotUp,
+} = require('./plugin');
+const {
+  getSummary,
+  getContentType,
+  Prometheus,
+  defaultRegister,
+  defaultNormalizers,
+} = require('@promster/metrics');
+
+exports.version = version;
+exports.promsterPlugin = promsterPlugin;
+exports.getRequestRecorder = getRequestRecorder;
+exports.signalIsUp = signalIsUp;
+exports.signalIsNotUp = signalIsNotUp;
+exports.getSummary = getSummary;
+exports.getContentType = getContentType;
+exports.Prometheus = Prometheus;
+exports.defaultRegister = defaultRegister;
+exports.defaultNormalizers = defaultNormalizers;

--- a/packages/fastify/modules/plugin/index.js
+++ b/packages/fastify/modules/plugin/index.js
@@ -1,0 +1,11 @@
+const {
+  default: promsterPlugin,
+  getRequestRecorder,
+  signalIsUp,
+  signalIsNotUp,
+} = require('./plugin');
+
+exports.promsterPlugin = promsterPlugin;
+exports.signalIsUp = signalIsUp;
+exports.signalIsNotUp = signalIsNotUp;
+exports.getRequestRecorder = getRequestRecorder;

--- a/packages/fastify/modules/plugin/plugin.js
+++ b/packages/fastify/modules/plugin/plugin.js
@@ -1,0 +1,81 @@
+const fp = require('fastify-plugin');
+const merge = require('merge-options');
+const {
+  Prometheus,
+  createMetricTypes,
+  createRequestRecorder,
+  createGcObserver,
+  defaultNormalizers,
+  getSummary,
+  getContentType,
+} = require('@promster/metrics');
+
+const defaultRouteOptions = {
+  route: { method: 'GET', url: '/metrics' },
+};
+
+let recordRequest;
+let upMetric;
+
+const extractPath = req => req.raw.originalUrl || req.raw.url;
+const getRequestRecorder = () => recordRequest;
+const signalIsUp = () => upMetric && upMetric.set(1);
+const signalIsNotUp = () => upMetric && upMetric.set(0);
+
+const plugin = async function(fastify, options) {
+  const defaultedOptions = merge(
+    createMetricTypes.defaultedOptions,
+    createRequestRecorder.defaultedOptions,
+    defaultNormalizers,
+    defaultRouteOptions,
+    options
+  );
+
+  const metricTypes = createMetricTypes(defaultedOptions);
+  const observeGc = createGcObserver(metricTypes);
+
+  recordRequest = createRequestRecorder(metricTypes, defaultedOptions);
+  upMetric = metricTypes && metricTypes.up;
+
+  observeGc();
+
+  fastify.decorate('Prometheus', Prometheus);
+  fastify.decorate('recordRequest', recordRequest);
+  fastify.decorateRequest('__promsterStartTime__', 0);
+
+  fastify.addHook('onRequest', async (req, _) => {
+    req.__promsterStartTime__ = process.hrtime();
+  });
+
+  fastify.addHook('onResponse', async (req, reply) => {
+    recordRequest(req.__promsterStartTime__, {
+      labels: {
+        method: defaultedOptions.normalizeMethod(req.raw.method),
+        // eslint-disable-next-line camelcase
+        status_code: defaultedOptions.normalizeStatusCode(reply.res.statusCode),
+        path: defaultedOptions.normalizePath(extractPath(req)),
+        ...(defaultedOptions.getLabelValues &&
+          defaultedOptions.getLabelValues(req, reply)),
+      },
+    });
+  });
+
+  fastify.route({
+    handler: async function(req, reply) {
+      reply
+        .type(getContentType())
+        .code(200)
+        .send(getSummary());
+    },
+    ...defaultedOptions.route,
+  });
+};
+
+module.exports.default = fp(plugin, {
+  fastify: '>= 1.6.0',
+  name: '@promster/fastify',
+});
+module.exports.getRequestRecorder = getRequestRecorder;
+module.exports.signalIsUp = signalIsUp;
+module.exports.signalIsNotUp = signalIsNotUp;
+module.exports.extractPath = extractPath;

--- a/packages/fastify/modules/plugin/plugin.spec.js
+++ b/packages/fastify/modules/plugin/plugin.spec.js
@@ -1,0 +1,140 @@
+const Fastify = require('fastify');
+const {
+  createRequestRecorder,
+  createGcObserver,
+} = require('@promster/metrics');
+const { extractPath, default: promsterPlugin } = require('./plugin');
+
+jest.mock('@promster/metrics', () => ({
+  Prometheus: 'MockPrometheus',
+  createMetricTypes: jest.fn(),
+  createRequestRecorder: jest.fn(() => jest.fn()),
+  createGcObserver: jest.fn(() => jest.fn()),
+  getSummary: jest.fn(() => 'metrics'),
+  getContentType: jest.fn(() => 'text'),
+  defaultNormalizers: {
+    normalizePath: jest.fn(_ => _),
+    normalizeStatusCode: jest.fn(_ => _),
+    normalizeMethod: jest.fn(_ => _),
+  },
+}));
+
+describe('extracting path', () => {
+  let extractedPath;
+  describe('with original url', () => {
+    const req = { raw: { originalUrl: 'originalUrl', url: 'nextUrl' } };
+
+    beforeEach(() => {
+      extractedPath = extractPath(req);
+    });
+
+    it('should extract original url', () => {
+      expect(extractedPath).toEqual(req.raw.originalUrl);
+    });
+  });
+
+  describe('with out original url', () => {
+    const req = { raw: { url: 'nextUrl' } };
+
+    beforeEach(() => {
+      extractedPath = extractPath(req);
+    });
+
+    it('should extract url', () => {
+      expect(extractedPath).toEqual(req.raw.url);
+    });
+  });
+});
+
+describe('plugin', () => {
+  let fastify;
+
+  beforeEach(async () => {
+    fastify = new Fastify();
+  });
+
+  afterEach(async () => {
+    await fastify.close();
+  });
+
+  describe('when registering plugin', () => {
+    let observeGc = jest.fn();
+
+    beforeEach(() => {
+      createGcObserver.mockReturnValue(jest.fn(observeGc));
+    });
+
+    it('should start observing garbage collection', async () => {
+      await fastify.register(promsterPlugin).ready();
+      expect(observeGc).toHaveBeenCalled();
+    });
+
+    describe('decorates fastify', () => {
+      it('should expose Prometheus on fastify', async () => {
+        await fastify.register(promsterPlugin).ready();
+
+        expect(fastify).toHaveProperty('Prometheus');
+        expect(fastify).toHaveProperty('recordRequest');
+      });
+    });
+
+    describe('when request starts', () => {
+      const method = 'GET';
+      const url = '/promster';
+
+      describe('decorates fastify request', () => {
+        it('should have __promsterStartTime__ on request', async () => {
+          fastify.route({
+            url,
+            method,
+            handler: (req, reply) => {
+              expect(req).toHaveProperty('__promsterStartTime__');
+              reply.send();
+            },
+          });
+
+          await fastify.register(promsterPlugin).ready();
+          await fastify.inject({ method, url });
+        });
+      });
+
+      describe('when the response finishes', () => {
+        let recordRequest = jest.fn();
+
+        beforeEach(async () => {
+          createRequestRecorder.mockReturnValue(jest.fn(recordRequest));
+          await fastify.register(promsterPlugin).ready();
+          await fastify.inject({ method, url });
+        });
+
+        it('should have observed the request', async () => {
+          expect(recordRequest).toHaveBeenCalled();
+        });
+
+        it('should pass labels to the observer', async () => {
+          expect(recordRequest).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+              labels: expect.objectContaining({
+                // eslint-disable-next-line camelcase
+                status_code: 404,
+                method,
+                path: url,
+              }),
+            })
+          );
+        });
+      });
+    });
+
+    describe('registers metrics route', () => {
+      it('returns metrics', async () => {
+        await fastify.register(promsterPlugin).ready();
+        const res = await fastify.inject({ method: 'GET', url: '/metrics' });
+
+        expect(res.headers['content-type']).toBe('text');
+        expect(res.body).toBe('metrics');
+      });
+    });
+  });
+});

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@promster/fastify",
+  "version": "1.0.0",
+  "description": "Fastify server integrations of promster",
+  "main": "modules/index.js",
+  "scripts": {
+    "prebuild": "rimraf dist/**",
+    "build": "exit 0"
+  },
+  "files": [
+    "readme.md",
+    "modules/**"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tdeekens/promster.git"
+  },
+  "author": "Tobias Deekens <nerd@tdeekens.name>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/tdeekens/promster/issues"
+  },
+  "homepage": "https://github.com/tdeekens/promster#readme",
+  "keywords": [
+    "metrics",
+    "continousdelivery",
+    "prometheus"
+  ],
+  "dependencies": {
+    "@promster/metrics": "^2.2.2",
+    "fastify-plugin": "^1.6.0",
+    "merge-options": "1.0.1"
+  },
+  "devDependencies": {
+    "fastify": "^2.6.0"
+  }
+}

--- a/packages/fastify/readme.md
+++ b/packages/fastify/readme.md
@@ -1,0 +1,8 @@
+<p align="center">
+  <b style="font-size: 25px">⏰ Promster - Measure metrics from Hapi/Express/Fastify servers with Prometheus 🚦</b><br />
+  <i>Promster is an Prometheus Exporter for Node.js servers written with Express, Hapi or Fastify.</i>
+</p>
+
+### `@promster/fastify`
+
+This repository is part of the `promster` mono repository. Please head [here](https://github.com/tdeekens/promster) for more information.

--- a/readme.md
+++ b/readme.md
@@ -2,9 +2,9 @@
   <img alt="Logo" height="150" src="https://raw.githubusercontent.com/tdeekens/promster/master/logo.png" /><br /><br />
 </p>
 
-<h2 align="center">⏰ Promster - Measure metrics from Hapi, express or Marble.js servers with Prometheus 🚦</h2>
+<h2 align="center">⏰ Promster - Measure metrics from Hapi, express, Marble.js or Fastify servers with Prometheus 🚦</h2>
 <p align="center">
-  <b>Promster is an Prometheus Exporter for Node.js servers written with Express, Hapi or Marble.js.</b>
+  <b>Promster is an Prometheus Exporter for Node.js servers written with Express, Hapi, Marble.js or Fastify.</b>
 </p>
 
 <p align="center">
@@ -13,6 +13,7 @@
   Hapi
   · Express
   · Marble.js
+  · Fastify
   · Prettier
   · Jest
   · ESLint
@@ -41,6 +42,7 @@
 | [`promster/hapi`](/packages/hapi)         | [![hapi Version][hapi-icon]][hapi-version]             | [![hapi Dependencies Status][hapi-dependencies-icon]][hapi-dependencies]             | [![hapi Downloads][hapi-downloads]][hapi-downloads]             |
 | [`promster/express`](/packages/express)   | [![express Version][express-icon]][express-version]    | [![express Dependencies Status][express-dependencies-icon]][express-dependencies]    | [![express Downloads][express-downloads]][express-downloads]    |
 | [`promster/marblejs`](/packages/marblejs) | [![marblejs Version][marblejs-icon]][marblejs-version] | [![marblejs Dependencies Status][marblejs-dependencies-icon]][marblejs-dependencies] | [![marblejs Downloads][marblejs-downloads]][marblejs-downloads] |
+| [`promster/fastify`](/packages/fastify)   | [![fastify Version][fastify-icon]][fastify-version]    | [![fastify Dependencies Status][fastify-dependencies-icon]][fastify-dependencies]    | [![fastify Downloads][fastify-downloads]][fastify-downloads]    |
 | [`promster/server`](/packages/server)     | [![server Version][server-icon]][server-version]       | [![server Dependencies Status][server-dependencies-icon]][server-dependencies]       | [![server Downloads][server-downloads]][server-downloads]       |
 | [`promster/metrics`](/packages/metrics)   | [![metrics Version][metrics-icon]][metrics-version]    | [![metrics Dependencies Status][metrics-dependencies-icon]][metrics-dependencies]    | [![metrics Downloads][metrics-downloads]][metrics-downloads]    |
 
@@ -147,6 +149,28 @@ Passing the `app` into the `createMiddleware` call attaches the internal `prom-c
 ```js
 // Create an e.g. custom counter
 const counter = new app.locals.Prometheus.Counter({
+  name: 'metric_name',
+  help: 'metric_help',
+});
+
+// to later increment it
+counter.inc();
+```
+
+### `@promster/fastify`
+
+```js
+const app = require('./your-fastify-app');
+const { promsterPlugin } = require('@promster/fastify');
+
+fastify.register(promsterPlugin):
+```
+
+Plugin attaches the internal `prom-client` to your Fastify instance. This may come in handy as later you can:
+
+```js
+// Create an e.g. custom counter
+const counter = new fastify.Prometheus.Counter({
   name: 'metric_name',
   help: 'metric_help',
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1340,6 +1340,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abstract-logging@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/abstract-logging/-/abstract-logging-1.0.0.tgz#8b7deafd310559bc28f77724dd1bb30177278c1b"
+  integrity sha1-i33q/TEFWbwo93ck3RuzAXcnjBs=
+
 acorn-globals@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
@@ -1389,7 +1394,7 @@ agentkeepalive@^3.4.1:
   dependencies:
     humanize-ms "^1.2.1"
 
-ajv@^6.10.0, ajv@^6.5.5, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.5.5, ajv@^6.8.1, ajv@^6.9.1, ajv@^6.9.2:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -1453,6 +1458,11 @@ aproba@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -1577,6 +1587,15 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+avvio@^6.1.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/avvio/-/avvio-6.2.1.tgz#d9a4e5ccb8411ff77dca42f24ad1137435893773"
+  integrity sha512-k+gTocL3yShwN1PtKEsSj7eFiApcZ4JZLAu/ecyzEb8jyx+Kmxb+7SXUsodB47g7fqhs/zkfsCdqq72a1ok5Ew==
+  dependencies:
+    archy "^1.0.0"
+    debug "^4.0.0"
+    fastq "^1.6.0"
 
 aws-sign2@~0.7.0:
   version "0.7.0"
@@ -2354,7 +2373,7 @@ debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -2399,7 +2418,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@3.3.0:
+deepmerge@3.3.0, deepmerge@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
   integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
@@ -2950,6 +2969,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-decode-uri-component@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
+
 fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
@@ -2977,10 +3001,62 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
+fast-json-stringify@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.15.3.tgz#09258f2e5cb67cadd2e1cfd0baecf5b808294643"
+  integrity sha512-p+ucnySTbrUQ9M7u8ygFIxrmpG8B+8O4/PvLDdh+RqMMgj/h6OoDb7U2lP+kqg3PDclQBFbSIArRhkorFwZLLg==
+  dependencies:
+    ajv "^6.8.1"
+    deepmerge "^3.0.0"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fast-redact@^1.4.4:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-1.5.0.tgz#302892f566750c4f5eec7b830bfc9bc473484034"
+  integrity sha512-Afo61CgUjkzdvOKDHn08qnZ0kwck38AOGcMlvSGzvJbIab6soAP5rdoQayecGCDsD69AiF9vJBXyq31eoEO2tQ==
+
+fast-safe-stringify@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
+  integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
+
+fastify-plugin@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-1.6.0.tgz#c8198b08608f20c502b5dad26b36e9ae27206d7c"
+  integrity sha512-lFa9txg8LZx4tljj33oG53nUXhVg0baZxtP9Pxi0dJmI0NQxzkDk5DS9kr3D7iMalUAp3mvIq16OQumc7eIvLA==
+  dependencies:
+    semver "^6.0.0"
+
+fastify@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/fastify/-/fastify-2.6.0.tgz#45397b760f75278633fe0dcb30fcb4a26d1f66f6"
+  integrity sha512-3GxGV2P8731o2S5T6ng5NMJ9S7vFpZA4mk2mJEbMbhQ5aj1HhNGBOe39TYa2gWRrJVJuXxYYYIlY/5cFhiHpNg==
+  dependencies:
+    abstract-logging "^1.0.0"
+    ajv "^6.9.2"
+    avvio "^6.1.1"
+    fast-json-stringify "^1.15.0"
+    find-my-way "^2.0.0"
+    flatstr "^1.0.12"
+    light-my-request "^3.2.0"
+    middie "^4.0.1"
+    pino "^5.11.1"
+    proxy-addr "^2.0.4"
+    readable-stream "^3.1.1"
+    rfdc "^1.1.2"
+    secure-json-parse "^1.0.0"
+    tiny-lru "^6.0.1"
+
+fastq@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.6.0.tgz#4ec8a38f4ac25f21492673adb7eae9cfef47d1c2"
+  integrity sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==
+  dependencies:
+    reusify "^1.0.0"
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -3026,6 +3102,15 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+find-my-way@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-2.1.0.tgz#dc9bfe2ab12ce8f965f489794134789e8fd56881"
+  integrity sha512-Hdx6ctcrzkZH5y9EREHtXryXAgc5Bc8z5Cvoa61y9kaoYj2KU4yXD6h8b6u0NUkYPVmQQeRdf0AtG1kQxQ+ukQ==
+  dependencies:
+    fast-decode-uri-component "^1.0.0"
+    safe-regex2 "^2.0.0"
+    semver-store "^0.3.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -3065,6 +3150,11 @@ flat-cache@^2.0.1:
     rimraf "2.6.3"
     write "1.0.3"
 
+flatstr@^1.0.12, flatstr@^1.0.9:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/flatstr/-/flatstr-1.0.12.tgz#c2ba6a08173edbb6c9640e3055b95e287ceb5931"
+  integrity sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw==
+
 flatted@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
@@ -3101,6 +3191,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+forwarded@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
+  integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3692,6 +3787,11 @@ ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
   integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
+ipaddr.js@1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
+  integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
 
 irregular-plurals@^2.0.0:
   version "2.0.0"
@@ -4603,6 +4703,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+light-my-request@^3.2.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/light-my-request/-/light-my-request-3.4.1.tgz#c30087005f6ae64ce5ef92c2484b1ab93c71ad3e"
+  integrity sha512-E1zMvRWjqsaCS60dTkD7c//xKV1KOFD2zo92Ru3o3e95lCfQSDCC9aS8MZm1V+zXaA/SeKDwK9gvrfaCseTusg==
+  dependencies:
+    ajv "^6.8.1"
+    readable-stream "^3.1.1"
+
 lint-staged@8.2.1:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-8.2.1.tgz#752fcf222d9d28f323a3b80f1e668f3654ff221f"
@@ -5021,6 +5129,14 @@ micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
+
+middie@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/middie/-/middie-4.0.1.tgz#24b4333034926ebd7831ed58766d050c1ce6300a"
+  integrity sha512-eYK6EEHZiYpQMYPmeCb/vC9ZzJg1HCqi1ot/fQs1sPZKt/XREgXouQ7g6c9J5XvDV5203JjbpovCYNkHcHgTpQ==
+  dependencies:
+    path-to-regexp "^3.0.0"
+    reusify "^1.0.2"
 
 mime-db@1.40.0:
   version "1.40.0"
@@ -5767,6 +5883,11 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
+path-to-regexp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.0.0.tgz#c981a218f3df543fa28696be2f88e0c58d2e012a"
+  integrity sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -5814,6 +5935,23 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pino-std-serializers@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz#cb5e3e58c358b26f88969d7e619ae54bdfcc1ae1"
+  integrity sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==
+
+pino@^5.11.1:
+  version "5.12.6"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-5.12.6.tgz#04a668278d7616db71871f1bd3e26f6918e05feb"
+  integrity sha512-LM5ug2b27uymIIkaBw54ncF+9DSf8S4z1uzw+Y5I94dRu3Z+lFuB13j0kg1InAeyxy+CsLGnWHKy9+zgTreFOg==
+  dependencies:
+    fast-redact "^1.4.4"
+    fast-safe-stringify "^2.0.6"
+    flatstr "^1.0.9"
+    pino-std-serializers "^2.3.0"
+    quick-format-unescaped "^3.0.2"
+    sonic-boom "^0.7.3"
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -5934,7 +6072,6 @@ prompts@^2.0.1:
 
 "prompts@git://github.com/terkelg/prompts.git#792824f8e5bfe3d632da0e48be23ab718b8f6646":
   version "0.1.4"
-  uid "792824f8e5bfe3d632da0e48be23ab718b8f6646"
   resolved "git://github.com/terkelg/prompts.git#792824f8e5bfe3d632da0e48be23ab718b8f6646"
   dependencies:
     clorox "^1.0.1"
@@ -5968,6 +6105,14 @@ protoduck@^5.0.1:
   integrity sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==
   dependencies:
     genfun "^5.0.0"
+
+proxy-addr@^2.0.4:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
+  integrity sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==
+  dependencies:
+    forwarded "~0.1.2"
+    ipaddr.js "1.9.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -6033,6 +6178,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+quick-format-unescaped@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-3.0.2.tgz#0137e94d8fb37ffeb70040535111c378e75396fb"
+  integrity sha512-FXTaCkwvpIlkdKeGDNgcq07SXWS383noQUuZjvdE1QcTt+eLuqof6/BDiEPqB59FWLie/l91+HtlJSw7iCViSA==
 
 quick-lru@^1.0.0:
   version "1.1.0"
@@ -6156,7 +6306,7 @@ read@1, read@~1.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-"readable-stream@2 || 3", readable-stream@^3.0.2:
+"readable-stream@2 || 3", readable-stream@^3.0.2, readable-stream@^3.1.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
   integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
@@ -6364,10 +6514,25 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+ret@~0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
+  integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
+
 retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
+reusify@^1.0.0, reusify@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.1.4.tgz#ba72cc1367a0ccd9cf81a870b3b58bd3ad07f8c2"
+  integrity sha512-5C9HXdzK8EAqN7JDif30jqsBzavB7wLpaubisuQIGHWf2gUXSpzy6ArX/+Da8RjFpagWsCn+pIgxTMAmKw9Zug==
 
 rimraf@2, rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
@@ -6417,6 +6582,13 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, 
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-regex2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-2.0.0.tgz#b287524c397c7a2994470367e0185e1916b1f5b9"
+  integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
+  dependencies:
+    ret "~0.2.0"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -6449,10 +6621,20 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
+secure-json-parse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-1.0.0.tgz#fa32c6778166b783cf6315db967944e63f7747d0"
+  integrity sha512-kMg4jXttRQzVyLebIDc+MRxCueJ/zsmHpCn59BRd0mZUCd+V02wNd7/Pds8Nyhv7jfLHo1KkUOzdIF7cRMU4LQ==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
+semver-store@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
+  integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
   version "5.7.0"
@@ -6622,6 +6804,13 @@ socks@~2.3.2:
   dependencies:
     ip "^1.1.5"
     smart-buffer "4.0.2"
+
+sonic-boom@^0.7.3:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-0.7.4.tgz#dc1740a900cf8646471f6ac1f4933a5c66c0ca60"
+  integrity sha512-8JRAJg0RxZtFLQMxolwETvWd2JSlH3ZGo/Z4xPxMbpqF14xCgVYPVeFCFOR3zyr3pcfG82QDVj6537Sx5ZWdNw==
+  dependencies:
+    flatstr "^1.0.9"
 
 sort-keys@^2.0.0:
   version "2.0.0"
@@ -7047,6 +7236,11 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+tiny-lru@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-6.0.1.tgz#558bd6b7232b8b9dfa482147539676fdd75a3a07"
+  integrity sha512-k/vdHz+bFALjmik0URLWBYNuO0hCABTL5dullbZBXvFDdlL8RrKaeLR6YuHfX+6ZXOLkHw+HpNLCUA7DtLMQmg==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
#### Summary

<!-- provide a short summary of your changes -->
this PR adds support to https://github.com/fastify/fastify 

Related issue: https://github.com/tdeekens/promster/issues/168

#### Description

<!-- provide some context -->
Implementation is very similar to express middleware.
- There is a plugin which has initialization step to enable gc observer and decorate fastify object with `Prometheus` and `recordRequest` properties.
- Plugin attaches `onRequest` and `onResponse` event listeners to track `hrtime` and record request metrics in the end.
- It also registers an endpoint to serve metrics for Prometheus.

#### Technical debt & future

<!--
  Which technical debt does this PR introduce?
  How do we plan to resolve it?
  What is the next step after this PR?
-->