### PR TITLE
feat: add passing request, response to normalizers

### DIFF
--- a/packages/express/modules/middleware/middleware.js
+++ b/packages/express/modules/middleware/middleware.js
@@ -38,22 +38,34 @@ const createMiddleware = ({ app, options } = {}) => {
 
   observeGc();
 
-  return (req, res, next) => {
+  return (request, response, next) => {
     const start = process.hrtime();
-    res.on('finish', () => {
+    response.on('finish', () => {
       const labels = Object.assign(
         {},
         {
-          method: defaultedOptions.normalizeMethod(req.method),
+          method: defaultedOptions.normalizeMethod(request.method, {
+            req: request,
+            res: response,
+          }),
           // eslint-disable-next-line camelcase
-          status_code: defaultedOptions.normalizeStatusCode(res.statusCode),
-          path: defaultedOptions.normalizePath(extractPath(req)),
+          status_code: defaultedOptions.normalizeStatusCode(
+            response.statusCode,
+            { req: request, res: response }
+          ),
+          path: defaultedOptions.normalizePath(extractPath(request), {
+            req: request,
+            res: response,
+          }),
         },
         defaultedOptions.getLabelValues &&
-          defaultedOptions.getLabelValues(req, res)
+          defaultedOptions.getLabelValues(request, response)
       );
 
-      if (defaultedOptions.skip && defaultedOptions.skip(req, res, labels))
+      if (
+        defaultedOptions.skip &&
+        defaultedOptions.skip(request, response, labels)
+      )
         return;
 
       recordRequest(start, {

--- a/packages/hapi/modules/plugin/plugin.js
+++ b/packages/hapi/modules/plugin/plugin.js
@@ -59,11 +59,18 @@ const createPlugin = ({ options: pluginOptions } = {}) => {
         const labels = Object.assign(
           {},
           {
-            path: defaultedOptions.normalizePath(extractPath(request)),
-            method: defaultedOptions.normalizeMethod(request.method),
+            path: defaultedOptions.normalizePath(extractPath(request), {
+              request,
+              response,
+            }),
+            method: defaultedOptions.normalizeMethod(request.method, {
+              request,
+              response,
+            }),
             // eslint-disable-next-line camelcase
             status_code: defaultedOptions.normalizeStatusCode(
-              extractStatusCode(request)
+              extractStatusCode(request),
+              { request, response }
             ),
           },
           defaultedOptions.getLabelValues &&

--- a/readme.md
+++ b/readme.md
@@ -239,9 +239,9 @@ When creating either the Express middleware or Hapi plugin the followin options 
 - `metricNames`: an object containing custom names for one or all metrics with keys of `up, countOfGcs, durationOfGc, reclaimedInGc, httpRequestDurationPerPercentileInMilliseconds, httpRequestDurationInMilliseconds, httpRequestDurationPerPercentileInSeconds, httpRequestDurationInSeconds`
 - `accuracies`: an `Array<String>` containing one of `ms`, `s` or both
 - `getLabelValues`: a function receiving `req` and `res` on reach request. It has to return an object with keys of the configured `labels` above and the respective values
-- `normalizePath`: a function called on each request to normalize the request's path
-- `normalizeStatusCode`: a function called on each request to normalize the respond's status code (e.g. to get 2xx, 5xx codes instead of detailed ones)
-- `normalizeMethod`: a function called on each request to normalize the request's method (to e.g. hide it fully)
+- `normalizePath`: a function called on each request to normalize the request's path. Invoked with `(path: string, { request, response })`
+- `normalizeStatusCode`: a function called on each request to normalize the respond's status code (e.g. to get 2xx, 5xx codes instead of detailed ones). Invoked with `(statusCode: nummber, { request, response })`
+- `normalizeMethod`: a function called on each request to normalize the request's method (to e.g. hide it fully). Invoked with `(method: string, { request, response })`
 - `skip`: a function called on each response giving the ability to skip a metric. The method receives `req`, `res` and `labels` and returns a boolean: `skip(req, res, labels) => Boolean`
 
 Moreover, both `@promster/hapi` and `@promster/express` expose the request recorder configured with the passed options and used to measure request timings. It allows easy tracking of other requests not handled through express or Hapi for instance calls to an external API while using promster's already defined metric types (the `httpRequestsHistogram` etc).


### PR DESCRIPTION
#### Summary

This augments `request` and `response` to be passed to all normalizers. This will be non-breaking as the standard argument (1st) will remain unchainged.

Closes #201 