### PR TITLE
Correct summary/histogram references in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,10 +126,10 @@ The following metrics are exposed:
 - `http_requests_total`: a Prometheus counter for the http request total
   - This metric is also exposed on the following histogram and summary which both have a `_sum` and `_count` and enabled for ease of use. It can be disabled by configuring with `metricTypes: Array<String>`.
 - `http_request_duration_seconds`: a Prometheus histogram with request time buckets in milliseconds (defaults to `[ 0.05, 0.1, 0.3, 0.5, 0.8, 1, 1.5, 2, 3, 5, 10 ]`)
-  - A summary exposes a `_sum` and `_count` which are a duplicate to the above counter metric.
-  - A summary can be used to compute percentiles with a PromQL query using the `histogram_quantile` function. It is advised to create a Prometheus recording rule for performance.
+  - A histogram exposes a `_sum` and `_count` which are a duplicate to the above counter metric.
+  - A histogram can be used to compute percentiles with a PromQL query using the `histogram_quantile` function. It is advised to create a Prometheus recording rule for performance.
 - `http_request_duration_per_percentile_seconds`: a Prometheus summary with request time percentiles in milliseconds (defaults to `[ 0.5, 0.9, 0.99 ]`)
-  - This metric is disabled by default and can be enabled by passing `metricTypes: ['httpRequestsSummary]`. It exists for cases in which the above summary is not suffient, slow or recording rules can not be set up.
+  - This metric is disabled by default and can be enabled by passing `metricTypes: ['httpRequestsSummary]`. It exists for cases in which the above histogram is not suffient, slow or recording rules can not be set up.
 
 In addition with each http request metric the following default labels are measured: `method`, `status_code` and `path`. You can configure more `labels` (see below).
 With all gargabe collection metrics a `gc_type` label with one of: `unknown`, `scavenge`, `mark_sweep_compact`, `scavenge_and_mark_sweep_compact`, `incremental_marking`, `weak_phantom` or `all` will be recored.


### PR DESCRIPTION
#### Summary

The README covers the Prometheus metrics and goes over how it provides a counter, histogram, and summary. While describing the histogram and summary the sections refer to each other, but both sections use the word "summary" which could confuse users unfamiliar with the details of Prometheus' Histograms and Summaries.

#### Description

Covered in Summary.

#### Technical debt & future

No tech debt introduced with this PR.
