### PR TITLE
fix: prefix http_requests_total metrics

### DIFF
--- a/packages/metrics/modules/create-metric-types/create-metric-types.js
+++ b/packages/metrics/modules/create-metric-types/create-metric-types.js
@@ -179,7 +179,7 @@ const getHttpRequestCounterMetric = options => ({
     asArray(options.metricNames.httpRequestsTotal).map(
       nameOfHttpRequestsTotalMetric =>
         new Prometheus.Counter({
-          name: nameOfHttpRequestsTotalMetric,
+          name: `${options.metricPrefix}${nameOfHttpRequestsTotalMetric}`,
           help: 'The total HTTP requests.',
           labelNames: defaultRequestLabels.concat(options.labels).sort(),
         })


### PR DESCRIPTION
#### Summary

Prefixes http_requests_total metric with the provided prefix. [See issue](https://github.com/tdeekens/promster/issues/257)

