### PR TITLE
@promster/hapi decorator fix

### DIFF
--- a/.changeset/popular-melons-relate.md
+++ b/.changeset/popular-melons-relate.md
@@ -1,0 +1,7 @@
+---
+"@promster/hapi": patch
+---
+
+@promster/hapi decorator fix
+
+We had a breaking change sneak in. The decorator of promster of exposing the Prometheus instance was changed from a property to a function returning the property. This reverts that change.

--- a/packages/hapi/modules/plugin/plugin.ts
+++ b/packages/hapi/modules/plugin/plugin.ts
@@ -139,7 +139,10 @@ const createPlugin = (
         server.ext('onPreResponse', onResponseHandler);
       }
 
-      server.decorate('server', 'Prometheus', () => Prometheus);
+      // NOTE: The type of the server.decorate only supports a function signature,
+      // even when the docs state that it can also be "other value" in the case of `server`.
+      // @ts-expect-error
+      server.decorate('server', 'Prometheus', Prometheus);
       server.decorate('server', 'recordRequest', recordRequest);
 
       return onRegistrationFinished?.();


### PR DESCRIPTION
This was an accidental breaking change when switching to TypeScript, probably because Hapi's typings are insufficient in this case.

When decorating with the `server` type, the decorator method doesn't have to be a function, and any value will work.

Fixes https://github.com/tdeekens/promster/issues/372