### PR TITLE
fix(types): update TPromsterOptions

### DIFF
--- a/.changeset/weak-coins-admire.md
+++ b/.changeset/weak-coins-admire.md
@@ -1,0 +1,5 @@
+---
+"@promster/types": patch
+---
+
+fix(types): update TPromsterOptions

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -17,8 +17,8 @@ export type TPromsterOptions = {
   normalizeMethod?: (method: string) => string;
   getLabelValues?: <Q, S>(request: Q, response: S) => TLabelValues;
   detectKubernetes?: boolean;
-  buckets: [number];
-  percentiles: [number];
+  buckets?: [number];
+  percentiles?: [number];
 };
 
 export type TMetricTypes = {


### PR DESCRIPTION
#### Summary

Make `buckets` and `percentiles` optional in `TPromsterOptions`

#### Description

Self explanatory, Fixes #378 
