### PR TITLE
fix(hapi): use correct status code attribute when Hapi responses are Boom errors

### DIFF
--- a/.changeset/fast-waves-hope.md
+++ b/.changeset/fast-waves-hope.md
@@ -1,0 +1,5 @@
+---
+'@promster/hapi': minor
+---
+
+Use correct status code when Hapi response is a Boom object

--- a/packages/hapi/package.json
+++ b/packages/hapi/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@promster/types": "^1.0.5",
+    "@types/boom": "^7.3.0",
     "@types/hapi": "18.0.3"
   }
 }


### PR DESCRIPTION
#### Summary

Supports properly setting `status_code` when a Hapi response is actually a Boom object.

#### Description

A common pattern for Hapi applications is to use [Boom objects](https://github.com/hapijs/boom) in responses. Under the hood, Hapi swaps the `response` object with the supplied Boom object. The result of this is that `status_code` is not populated properly when adding metrics - the `status_code` will simply be `undefined` in cases where a response was delegated from a Boom object.

This change introduces support for extracting the correct status code off a Boom object while maintaining the existing behavior for pulling status codes off normal `response` objects.

#### Technical debt & future

N/A
