### PR TITLE
fix(express-type): changed TApp type

### DIFF
--- a/.changeset/four-pigs-relax.md
+++ b/.changeset/four-pigs-relax.md
@@ -1,0 +1,5 @@
+---
+'@promster/express': major
+---
+
+changed TApp typing

--- a/.changeset/four-pigs-relax.md
+++ b/.changeset/four-pigs-relax.md
@@ -1,5 +1,5 @@
 ---
-'@promster/express': major
+'@promster/express': patch
 ---
 
 changed TApp typing

--- a/packages/express/modules/middleware/middleware.ts
+++ b/packages/express/modules/middleware/middleware.ts
@@ -1,7 +1,6 @@
 import type { TPromsterOptions, TMetricTypes } from '@promster/types';
 import type { TRequestRecorder } from '@promster/metrics';
-import { Request, Response, NextFunction } from 'express';
-import { Server } from 'http';
+import { Application, Request, Response, NextFunction } from 'express';
 
 import merge from 'merge-options';
 import {
@@ -13,8 +12,8 @@ import {
   isRunningInKubernetes,
 } from '@promster/metrics';
 
-class TApp extends Server {
-  locals?: Record<string, unknown>;
+interface TApp extends Application {
+  locals: Record<string, unknown>;
 }
 
 type TLocaleTarget = {


### PR DESCRIPTION
#### Summary

When we use a createMiddleware TS throw an error of wrong object (Express application).

<!-- provide a short summary of your changes -->

#### Description

`Type 'Application' is missing the following properties from type 'TApp': setTimeout, maxHeadersCount, timeout, headersTimeout, and 9 more.ts(2740)`
<!-- provide some context -->

solves #499 