### PR TITLE
Spell check

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,22 @@
+{
+  "words": [
+    "changesets",
+    "codecov",
+    "eventloop",
+    "fastify",
+    "gctype",
+    "grafana",
+    "hrtime",
+    "initialisation",
+    "kubernetes",
+    "libuv",
+    "makepanic",
+    "marblejs",
+    "middlewares",
+    "promster",
+    "proxied",
+    "quantile",
+    "sematext"
+  ],
+  "ignorePaths": ["**/CHANGELOG.md"]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,10 @@ jobs:
         run: yarn install
       - name: Lint
         run: yarn lint
+      - name: Spell check
+        uses: streetsidesoftware/cspell-action@main
+        with:
+          files: '**/*.{md,ts}'
       - name: Build
         run: yarn build
       - name: Test

--- a/packages/hapi/src/plugin/plugin.ts
+++ b/packages/hapi/src/plugin/plugin.ts
@@ -170,7 +170,7 @@ const createPlugin = (
         if (doesResponseNeedInvocation) response.continue();
       };
 
-      // NOTE: This version detection allows us to graceully support both new and old Hapi APIs.
+      // NOTE: This version detection allows us to gracefully support both new and old Hapi APIs.
       // This is very hard to type as we would have to import two aliased versions of types.
       if (areServerEventsSupported) {
         // @ts-expect-error

--- a/packages/metrics/src/create-metric-types/create-metric-types.ts
+++ b/packages/metrics/src/create-metric-types/create-metric-types.ts
@@ -74,9 +74,9 @@ const getDefaultMetrics = (options: TDefaultedPromsterOptions) => ({
       })
   ),
   countOfGcs: asArray(options.metricNames.countOfGcs).map(
-    (nameOfCounfOfGcsMetric: string) =>
+    (nameOfCountOfGcsMetric: string) =>
       new Prometheus.Counter({
-        name: `${options.metricPrefix}${nameOfCounfOfGcsMetric}`,
+        name: `${options.metricPrefix}${nameOfCountOfGcsMetric}`,
         help: 'Count of total garbage collections.',
         labelNames: defaultGcLabels,
       })

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
@@ -1,6 +1,6 @@
 const {
   sortLabels,
-  endMeasurmentFrom,
+  endMeasurementFrom,
   createRequestRecorder,
 } = require('./create-request-recorder');
 
@@ -17,12 +17,12 @@ describe('sortLabels', () => {
   });
 });
 
-describe('endMeasurmentFrom', () => {
+describe('endMeasurementFrom', () => {
   const start = [1, 2];
   let measurement;
 
   beforeEach(() => {
-    measurement = endMeasurmentFrom(start);
+    measurement = endMeasurementFrom(start);
   });
 
   it('should have millisecond duration', () => {

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.ts
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.ts
@@ -45,7 +45,7 @@ const sortLabels = (unsortedLabels: TLabelValues): TLabelValues =>
       return sortedLabels;
     }, {});
 
-const endMeasurmentFrom = (start: TRequestTiming) => {
+const endMeasurementFrom = (start: TRequestTiming) => {
   const [seconds, nanoseconds] = process.hrtime(start);
 
   return {
@@ -96,7 +96,7 @@ const createRequestRecorder = (
   );
 
   return (start: TRequestTiming, recordingOptions: TRecordingOptions) => {
-    const { durationMs, durationS } = endMeasurmentFrom(start);
+    const { durationMs, durationS } = endMeasurementFrom(start);
     const labels = sortLabels(recordingOptions.labels);
 
     if (
@@ -196,4 +196,4 @@ const createRequestRecorder = (
 
 createRequestRecorder.defaultOptions = defaultOptions;
 
-export { createRequestRecorder, sortLabels, endMeasurmentFrom };
+export { createRequestRecorder, sortLabels, endMeasurementFrom };

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ The following metrics are exposed:
 - `http_response_content_length_bytes`: a Prometheus histogram with the request content length in bytes (defaults to `[ 100000, 200000, 500000, 1000000, 1500000, 2000000, 3000000, 5000000, 10000000, ]`)
 
 In addition with each http request metric the following default labels are measured: `method`, `status_code` and `path`. You can configure more `labels` (see below).
-With all garbage collection metrics a `gc_type` label with one of: `unknown`, `scavenge`, `mark_sweep_compact`, `scavenge_and_mark_sweep_compact`, `incremental_marking`, `weak_phantom` or `all` will be recored.
+With all garbage collection metrics a `gc_type` label with one of: `unknown`, `scavenge`, `mark_sweep_compact`, `scavenge_and_mark_sweep_compact`, `incremental_marking`, `weak_phantom` or `all` will be recorded.
 
 Given you pass `{ accuracies: ['ms'], metricTypes: ['httpRequestsTotal', 'httpRequestsSummary', 'httpRequestsHistogram'] }` you would get millisecond based metrics instead.
 
@@ -245,7 +245,7 @@ When creating either the Express middleware or Hapi plugin the following options
 - `accuracies`: an `Array<String>` containing one of `ms`, `s` or both
 - `getLabelValues`: a function receiving `req` and `res` on reach request. It has to return an object with keys of the configured `labels` above and the respective values
 - `normalizePath`: a function called on each request to normalize the request's path. Invoked with `(path: string, { request, response })`
-- `normalizeStatusCode`: a function called on each request to normalize the respond's status code (e.g. to get 2xx, 5xx codes instead of detailed ones). Invoked with `(statusCode: nummber, { request, response })`
+- `normalizeStatusCode`: a function called on each request to normalize the respond's status code (e.g. to get 2xx, 5xx codes instead of detailed ones). Invoked with `(statusCode: number, { request, response })`
 - `normalizeMethod`: a function called on each request to normalize the request's method (to e.g. hide it fully). Invoked with `(method: string, { request, response })`
 - `skip`: a function called on each response giving the ability to skip a metric. The method receives `req`, `res` and `labels` and returns a boolean: `skip(req, res, labels) => Boolean`
 - `detectKubernetes`: a boolean defaulting to `false`. Whenever `true`is passed the process does not run within Kubernetes any metric intake is skipped (good e.g. during testing).

--- a/red-chefs-smoke.md
+++ b/red-chefs-smoke.md
@@ -1,0 +1,6 @@
+---
+"@promster/hapi": patch
+"@promster/metrics": patch
+---
+
+Added spell check as a GitHub Action


### PR DESCRIPTION
#### Summary

This PR lets the GitHub workflow run spell check.

#### Description

An added step in the `install` workflow on GitHub Actions run `cspell` commmand to check spelling in `*.md` and `*.ts` files.

#### Technical debt & future

The dictionary might be a bit tedious to maintain?
