### PR TITLE
fix: typescript dev dependency of ts-essentials

### DIFF
--- a/.changeset/happy-coats-jam.md
+++ b/.changeset/happy-coats-jam.md
@@ -1,0 +1,5 @@
+---
+"@promster/metrics": patch
+---
+
+Fix unmet dev dependency of ts-essentials.

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -48,7 +48,8 @@
   "devDependencies": {
     "@promster/types": "^3.1.4",
     "@types/lodash": "4.14.176",
-    "prom-client": "14.0.0"
+    "prom-client": "14.0.0",
+    "typescript": "4.4.4"
   },
   "optionalDependencies": {
     "@sematext/gc-stats": "1.5.5"


### PR DESCRIPTION
Closes #761 