### PR TITLE
refactor: to use process.hrtime.bigint

### DIFF
--- a/.changeset/new-carrots-admire.md
+++ b/.changeset/new-carrots-admire.md
@@ -1,0 +1,15 @@
+---
+"@promster/apollo": patch
+"@promster/express": patch
+"@promster/fastify": patch
+"@promster/hapi": patch
+"@promster/marblejs": patch
+"@promster/metrics": major
+"@promster/types": patch
+---
+
+Refactor to use `process.hrtime.bigint()` over `process.hrtime()`.
+
+The [Node.js documentation](https://nodejs.org/api/process.html#processhrtimetime) lists `process.hrtime([time])` as a [legacy feature](https://nodejs.org/api/documentation.html#stability-index). It is no longer recommended for use, and should be avoided. As such it is recommended to use  `process.hrtime.bigint()` which works slightly different. 
+
+The breaking change in API is towards `recordRequest` which as a `start` paramater does not accept a `[number, number]` anymore but a `bigint`. Essentially the return of calling `process.hrtime.bigint()` over `process.hrtime()`.

--- a/.changeset/new-carrots-admire.md
+++ b/.changeset/new-carrots-admire.md
@@ -1,15 +1,27 @@
 ---
-"@promster/apollo": patch
-"@promster/express": patch
-"@promster/fastify": patch
-"@promster/hapi": patch
-"@promster/marblejs": patch
-"@promster/metrics": major
-"@promster/types": patch
+'@promster/apollo': patch
+'@promster/express': patch
+'@promster/fastify': patch
+'@promster/hapi': patch
+'@promster/marblejs': patch
+'@promster/metrics': minor
+'@promster/types': patch
 ---
 
 Refactor to use `process.hrtime.bigint()` over `process.hrtime()`.
 
-The [Node.js documentation](https://nodejs.org/api/process.html#processhrtimetime) lists `process.hrtime([time])` as a [legacy feature](https://nodejs.org/api/documentation.html#stability-index). It is no longer recommended for use, and should be avoided. As such it is recommended to use  `process.hrtime.bigint()` which works slightly different. 
+The [Node.js documentation](https://nodejs.org/api/process.html#processhrtimetime) lists `process.hrtime([time])` as a [legacy feature](https://nodejs.org/api/documentation.html#stability-index). It is no longer recommended for use, and should be avoided. As such it is recommended to use `process.hrtime.bigint()` which works slightly different.
 
-The breaking change in API is towards `recordRequest` which as a `start` paramater does not accept a `[number, number]` anymore but a `bigint`. Essentially the return of calling `process.hrtime.bigint()` over `process.hrtime()`.
+This change is backwards compatible. A new `timing` module was added to `@promster/metrics` which encapsulates timings so you never have to worry about the details.
+
+```diff
+import { getRequestRecorder } = require('@promster/express');
++import { timing } = require('@promster/express');
+
++const requestTiming = timing.start();
+-const requestTiming = process.hrtime();
+
+recordRequest(requestTiming);
+```
+
+We recommend to change all explicit calls to `process.hrtime()` with calls to `timing.start()` over time. The `recordRequest` function will continue to accept a `[number, number]` as the return of `process.hrtime()` so you can change code as you work with it.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:ci": "cross-env NODE_ENV=test npm test -- --no-watchman",
     "test:coverage": "cross-env NODE_ENV=test npm test -- --coverage",
     "test:watch": "cross-env NODE_ENV=test npm test -- --watch",
-    "test": "cross-env NODE_ENV=test jest --config .jestrc.test.json --forceExit",
+    "test": "cross-env NODE_ENV=test jest --config .jestrc.test.json --forceExit --runInBand",
     "typecheck": "tsc --noEmit"
   },
   "author": "Tobias Deekens <nerd@tdeekens.name>",

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -5,6 +5,7 @@ import {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 } from '@promster/metrics';
 
 export {
@@ -16,4 +17,5 @@ export {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 };

--- a/packages/apollo/src/plugin/plugin.ts
+++ b/packages/apollo/src/plugin/plugin.ts
@@ -114,11 +114,11 @@ const createPlugin = ({ options }: TPluginOptions = { options: undefined }) => {
     },
 
     async requestDidStart() {
-      const requestStart = process.hrtime();
+      const requestStart = process.hrtime.bigint();
 
       return {
         async parsingDidStart(parsingRequestContext) {
-          const parseStart = process.hrtime();
+          const parseStart = process.hrtime.bigint();
 
           return async (error) => {
             const { durationS } = endMeasurementFrom(parseStart);
@@ -139,7 +139,7 @@ const createPlugin = ({ options }: TPluginOptions = { options: undefined }) => {
         },
 
         async validationDidStart(validationRequestContext) {
-          const validationStart = process.hrtime();
+          const validationStart = process.hrtime.bigint();
 
           return async (error) => {
             const { durationS } = endMeasurementFrom(validationStart);
@@ -162,7 +162,7 @@ const createPlugin = ({ options }: TPluginOptions = { options: undefined }) => {
         async executionDidStart(executionRequestContext) {
           return {
             willResolveField({ info }) {
-              const fieldResolveStart = process.hrtime();
+              const fieldResolveStart = process.hrtime.bigint();
 
               return (error) => {
                 const { durationS } = endMeasurementFrom(fieldResolveStart);

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -10,6 +10,7 @@ import {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 } from '@promster/metrics';
 
 export {
@@ -22,4 +23,5 @@ export {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 };

--- a/packages/express/src/middleware/middleware.ts
+++ b/packages/express/src/middleware/middleware.ts
@@ -16,6 +16,7 @@ import {
   createGcObserver,
   defaultNormalizers,
   skipMetricsInEnvironment,
+  timing,
 } from '@promster/metrics';
 
 interface TApp extends Application {
@@ -91,7 +92,7 @@ const createMiddleware = (
   }
 
   return (request: Request, response: Response, next: NextFunction) => {
-    const start = process.hrtime.bigint();
+    const requestTiming = timing.start();
 
     response.on('finish', () => {
       const labels = Object.assign(
@@ -127,7 +128,7 @@ const createMiddleware = (
       );
 
       if (!shouldSkipByRequest && !shouldSkipMetricsByEnvironment) {
-        recordRequest(start, {
+        recordRequest(requestTiming, {
           labels,
           requestContentLength,
           responseContentLength,

--- a/packages/express/src/middleware/middleware.ts
+++ b/packages/express/src/middleware/middleware.ts
@@ -91,7 +91,8 @@ const createMiddleware = (
   }
 
   return (request: Request, response: Response, next: NextFunction) => {
-    const start = process.hrtime();
+    const start = process.hrtime.bigint();
+
     response.on('finish', () => {
       const labels = Object.assign(
         {},

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -10,6 +10,7 @@ import {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 } from '@promster/metrics';
 
 export {
@@ -22,4 +23,5 @@ export {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 };

--- a/packages/fastify/src/plugin/plugin.ts
+++ b/packages/fastify/src/plugin/plugin.ts
@@ -82,7 +82,7 @@ const createPlugin = async (
 
   fastify.addHook('onRequest', async (request, _) => {
     // @ts-expect-error
-    request.__promsterStartTime__ = process.hrtime();
+    request.__promsterStartTime__ = process.hrtime.bigint();
   });
 
   fastify.addHook('onResponse', async (request, reply) => {

--- a/packages/fastify/src/plugin/plugin.ts
+++ b/packages/fastify/src/plugin/plugin.ts
@@ -3,9 +3,8 @@ import type {
   THttpMetrics,
   TGcMetrics,
   TDefaultedPromsterOptions,
-  TRequestTiming,
 } from '@promster/types';
-import type { TRequestRecorder } from '@promster/metrics';
+import type { TRequestRecorder, TPromsterTiming } from '@promster/metrics';
 import { FastifyInstance, FastifyRequest } from 'fastify';
 
 import fastifyPlugin from 'fastify-plugin';
@@ -18,6 +17,7 @@ import {
   createGcObserver,
   defaultNormalizers,
   skipMetricsInEnvironment,
+  timing,
 } from '@promster/metrics';
 import pkg from '../../package.json';
 
@@ -78,11 +78,11 @@ const createPlugin = async (
 
   fastify.decorate('Prometheus', Prometheus);
   fastify.decorate('recordRequest', recordRequest);
-  fastify.decorateRequest<TRequestTiming | null>('__promsterStartTime__', null);
+  fastify.decorateRequest<TPromsterTiming | null>('__promsterTiming__', null);
 
   fastify.addHook('onRequest', async (request, _) => {
     // @ts-expect-error
-    request.__promsterStartTime__ = process.hrtime.bigint();
+    request.__promsterTiming__ = timing.start();
   });
 
   fastify.addHook('onResponse', async (request, reply) => {
@@ -118,7 +118,7 @@ const createPlugin = async (
 
     if (!shouldSkipByRequest && !shouldSkipMetricsByEnvironment) {
       // @ts-expect-error
-      recordRequest(request.__promsterStartTime__ as TRequestTiming, {
+      recordRequest(request.__promsterTiming__, {
         labels,
         requestContentLength,
         responseContentLength,

--- a/packages/hapi/src/index.ts
+++ b/packages/hapi/src/index.ts
@@ -13,6 +13,7 @@ import {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 } from '@promster/metrics';
 
 const instrument = async (server: Server, options: TPromsterOptions) =>
@@ -29,4 +30,5 @@ export {
   defaultRegister,
   defaultNormalizers,
   instrument,
+  timing,
 };

--- a/packages/hapi/src/plugin/plugin.ts
+++ b/packages/hapi/src/plugin/plugin.ts
@@ -29,7 +29,7 @@ import {
 interface TPromsterRequest extends Request {
   plugins: {
     promster: {
-      start: [number, number];
+      start: bigint;
     };
   };
 }
@@ -132,7 +132,7 @@ const createPlugin = (
         request: TPromsterRequest,
         h: ResponseToolkit
       ) => {
-        request.plugins.promster = { start: process.hrtime() };
+        request.plugins.promster = { start: process.hrtime.bigint() };
         // @ts-expect-error
         return doesResponseNeedInvocation ? h.continue() : h.continue;
       };

--- a/packages/hapi/src/plugin/plugin.ts
+++ b/packages/hapi/src/plugin/plugin.ts
@@ -4,7 +4,7 @@ import type {
   THttpMetrics,
   TGcMetrics,
 } from '@promster/types';
-import type { TRequestRecorder } from '@promster/metrics';
+import type { TRequestRecorder, TPromsterTiming } from '@promster/metrics';
 import type {
   Plugin,
   Request,
@@ -24,12 +24,13 @@ import {
   createGcObserver,
   defaultNormalizers,
   skipMetricsInEnvironment,
+  timing,
 } from '@promster/metrics';
 
 interface TPromsterRequest extends Request {
   plugins: {
     promster: {
-      start: bigint;
+      timing: TPromsterTiming;
     };
   };
 }
@@ -132,7 +133,7 @@ const createPlugin = (
         request: TPromsterRequest,
         h: ResponseToolkit
       ) => {
-        request.plugins.promster = { start: process.hrtime.bigint() };
+        request.plugins.promster = { timing: timing.start() };
         // @ts-expect-error
         return doesResponseNeedInvocation ? h.continue() : h.continue;
       };
@@ -175,7 +176,7 @@ const createPlugin = (
         );
 
         if (!shouldSkipByRequest && !shouldSkipMetricsByEnvironment) {
-          recordRequest(request.plugins.promster.start, {
+          recordRequest(request.plugins.promster.timing, {
             labels,
             requestContentLength,
             responseContentLength,

--- a/packages/marblejs/src/index.ts
+++ b/packages/marblejs/src/index.ts
@@ -10,6 +10,7 @@ import {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 } from '@promster/metrics';
 
 export {
@@ -22,4 +23,5 @@ export {
   Prometheus,
   defaultRegister,
   defaultNormalizers,
+  timing,
 };

--- a/packages/marblejs/src/middleware/middleware.ts
+++ b/packages/marblejs/src/middleware/middleware.ts
@@ -51,7 +51,7 @@ type TRecordHandlerOps = TDefaultedPromsterOptions & {
 };
 type TStamp = {
   req: HttpRequest;
-  start: [number, number];
+  start: bigint;
 };
 
 const recordHandler =
@@ -124,7 +124,7 @@ const createMiddleware = ({ options }: TMiddlewareOptions = {}) => {
 
   function middleware(req$: Observable<HttpRequest>, res: HttpResponse) {
     return req$.pipe(
-      map((req) => ({ req, start: process.hrtime() })),
+      map((req) => ({ req, start: process.hrtime.bigint() })),
       tap(
         recordHandler(res, shouldSkipMetricsByEnvironment, allDefaultedOptions)
       ),

--- a/packages/marblejs/src/middleware/middleware.ts
+++ b/packages/marblejs/src/middleware/middleware.ts
@@ -5,7 +5,7 @@ import type {
   TGcMetrics,
   TLabelValues,
 } from '@promster/types';
-import type { TRequestRecorder } from '@promster/metrics';
+import type { TRequestRecorder, TPromsterTiming } from '@promster/metrics';
 
 import merge from 'merge-options';
 import { HttpRequest, HttpResponse } from '@marblejs/core';
@@ -18,6 +18,7 @@ import {
   createGcObserver,
   defaultNormalizers,
   skipMetricsInEnvironment,
+  timing,
 } from '@promster/metrics';
 
 const extractPath = (req: HttpRequest): string => req.originalUrl || req.url;
@@ -51,7 +52,7 @@ type TRecordHandlerOps = TDefaultedPromsterOptions & {
 };
 type TStamp = {
   req: HttpRequest;
-  start: bigint;
+  timing: TPromsterTiming;
 };
 
 const recordHandler =
@@ -68,7 +69,7 @@ const recordHandler =
         map((req) => ({ req, res }))
       )
       .subscribe(() => {
-        const { req, start } = stamp;
+        const { req, timing } = stamp;
         const labels = Object.assign(
           {},
           {
@@ -87,7 +88,7 @@ const recordHandler =
         const requestContentLength = Number(req.headers['content-length'] ?? 0);
 
         if (!shouldSkipByRequest && !shouldSkipMetricsByEnvironment) {
-          recordRequest(start, {
+          recordRequest(timing, {
             labels,
             requestContentLength,
             responseContentLength,
@@ -124,7 +125,7 @@ const createMiddleware = ({ options }: TMiddlewareOptions = {}) => {
 
   function middleware(req$: Observable<HttpRequest>, res: HttpResponse) {
     return req$.pipe(
-      map((req) => ({ req, start: process.hrtime.bigint() })),
+      map((req) => ({ req, timing: timing.start() })),
       tap(
         recordHandler(res, shouldSkipMetricsByEnvironment, allDefaultedOptions)
       ),

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
@@ -1,4 +1,5 @@
 const { createRequestRecorder } = require('./create-request-recorder');
+const { timing } = require('../timing');
 
 describe('createRequestRecorder', () => {
   const createHttpMetrics = () => ({
@@ -33,7 +34,7 @@ describe('createRequestRecorder', () => {
       a: 'b',
     },
   };
-  const start = BigInt(1232768515903650n);
+  const testTiming = timing.start();
   let metrics;
   let recordRequest;
 
@@ -46,7 +47,7 @@ describe('createRequestRecorder', () => {
       recordRequest = createRequestRecorder(metrics, {
         metricTypes: ['httpContentLengthHistogram'],
       });
-      recordRequest(start, {
+      recordRequest(testTiming, {
         ...recordingOptions,
         requestContentLength: 123,
         responseContentLength: 456,
@@ -69,7 +70,7 @@ describe('createRequestRecorder', () => {
   describe('without content length', () => {
     beforeEach(() => {
       recordRequest = createRequestRecorder(metrics);
-      recordRequest(start, recordingOptions);
+      recordRequest(testTiming, recordingOptions);
     });
 
     it('should not record on `httpRequestContentLengthInBytes`', () => {
@@ -88,7 +89,7 @@ describe('createRequestRecorder', () => {
   describe('without accuracy', () => {
     beforeEach(() => {
       recordRequest = createRequestRecorder(metrics);
-      recordRequest(start, recordingOptions);
+      recordRequest(testTiming, recordingOptions);
     });
 
     it('should record on `httpRequestDurationInSeconds`', () => {
@@ -107,7 +108,7 @@ describe('createRequestRecorder', () => {
   describe('with second accuracy', () => {
     beforeEach(() => {
       recordRequest = createRequestRecorder(metrics, {});
-      recordRequest(start, recordingOptions);
+      recordRequest(testTiming, recordingOptions);
     });
 
     it('should record on `httpRequestDurationInSeconds`', () => {
@@ -128,7 +129,7 @@ describe('createRequestRecorder', () => {
       recordRequest = createRequestRecorder(metrics, {
         metricTypes: ['httpRequestsTotal'],
       });
-      recordRequest(start, recordingOptions);
+      recordRequest(testTiming, recordingOptions);
     });
     it('should record on `httpRequestsTotal`', () => {
       expect(metrics.httpRequestsTotal[0].inc).toHaveBeenCalledWith(

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.spec.js
@@ -33,7 +33,7 @@ describe('createRequestRecorder', () => {
       a: 'b',
     },
   };
-  const start = [1, 2];
+  const start = BigInt(1232768515903650n);
   let metrics;
   let recordRequest;
 

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.ts
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.ts
@@ -3,13 +3,13 @@ import type {
   TDefaultedPromsterOptions,
   TLabelValues,
   THttpMetrics,
-  TRequestTiming,
 } from '@promster/types';
 
 import merge from 'merge-options';
 import { skipMetricsInEnvironment } from '../environment';
 import { sortLabels } from '../sort-labels';
 import { endMeasurementFrom } from '../end-measurement-from';
+import { Timing } from '../timing';
 
 type TRecordingOptions = {
   labels: TLabelValues;
@@ -17,8 +17,9 @@ type TRecordingOptions = {
   responseContentLength?: number;
 };
 
+type TLegacyTiming = [number, number];
 export type TRequestRecorder = (
-  startTime: TRequestTiming,
+  timing: Timing | TLegacyTiming,
   recordingOptions: TRecordingOptions
 ) => void;
 
@@ -26,6 +27,10 @@ const defaultOptions: TPromsterOptions = {
   skip: () => false,
   detectKubernetes: false,
 };
+
+function isTiming(timing: Timing | TLegacyTiming): timing is Timing {
+  return !Array.isArray(timing);
+}
 
 const createRequestRecorder = (
   metrics: THttpMetrics,
@@ -39,11 +44,17 @@ const createRequestRecorder = (
     defaultedRecorderOptions
   );
 
-  return (startTime: TRequestTiming, recordingOptions: TRecordingOptions) => {
-    const { durationS } = endMeasurementFrom(startTime);
+  return (
+    timing: Timing | TLegacyTiming,
+    recordingOptions: TRecordingOptions
+  ) => {
+    const durationS = isTiming(timing)
+      ? timing.end().value().seconds
+      : endMeasurementFrom(timing).durationS;
+
     const labels = sortLabels(recordingOptions.labels);
 
-    if (!shouldSkipMetricsByEnvironment) {
+    if (!shouldSkipMetricsByEnvironment && durationS !== undefined) {
       metrics.httpRequestDurationInSeconds?.forEach(
         (httpRequestDurationInSecondsMetricType) => {
           httpRequestDurationInSecondsMetricType.observe(labels, durationS);
@@ -51,7 +62,7 @@ const createRequestRecorder = (
       );
     }
 
-    if (!shouldSkipMetricsByEnvironment) {
+    if (!shouldSkipMetricsByEnvironment && durationS !== undefined) {
       metrics.httpRequestDurationPerPercentileInSeconds?.forEach(
         (httpRequestDurationPerPercentileInSecondsMetricType) => {
           httpRequestDurationPerPercentileInSecondsMetricType.observe(
@@ -62,7 +73,7 @@ const createRequestRecorder = (
       );
     }
 
-    if (!shouldSkipMetricsByEnvironment) {
+    if (!shouldSkipMetricsByEnvironment && durationS !== undefined) {
       metrics.httpRequestsTotal?.forEach((httpRequestsTotalMetricType) => {
         httpRequestsTotalMetricType.inc(labels);
       });

--- a/packages/metrics/src/create-request-recorder/create-request-recorder.ts
+++ b/packages/metrics/src/create-request-recorder/create-request-recorder.ts
@@ -18,7 +18,7 @@ type TRecordingOptions = {
 };
 
 export type TRequestRecorder = (
-  start: TRequestTiming,
+  startTime: TRequestTiming,
   recordingOptions: TRecordingOptions
 ) => void;
 
@@ -39,8 +39,8 @@ const createRequestRecorder = (
     defaultedRecorderOptions
   );
 
-  return (start: TRequestTiming, recordingOptions: TRecordingOptions) => {
-    const { durationS } = endMeasurementFrom(start);
+  return (startTime: TRequestTiming, recordingOptions: TRecordingOptions) => {
+    const { durationS } = endMeasurementFrom(startTime);
     const labels = sortLabels(recordingOptions.labels);
 
     if (!shouldSkipMetricsByEnvironment) {

--- a/packages/metrics/src/end-measurement-from/end-measurement-from.spec.js
+++ b/packages/metrics/src/end-measurement-from/end-measurement-from.spec.js
@@ -1,7 +1,7 @@
 const { endMeasurementFrom } = require('./end-measurement-from');
 
 describe('endMeasurementFrom', () => {
-  const start = [1, 2];
+  const start = process.hrtime.bigint();
   let measurement;
 
   beforeEach(() => {

--- a/packages/metrics/src/end-measurement-from/end-measurement-from.spec.js
+++ b/packages/metrics/src/end-measurement-from/end-measurement-from.spec.js
@@ -1,7 +1,7 @@
 const { endMeasurementFrom } = require('./end-measurement-from');
 
 describe('endMeasurementFrom', () => {
-  const start = process.hrtime.bigint();
+  const start = [1, 2];
   let measurement;
 
   beforeEach(() => {

--- a/packages/metrics/src/end-measurement-from/end-measurement-from.ts
+++ b/packages/metrics/src/end-measurement-from/end-measurement-from.ts
@@ -1,12 +1,12 @@
 import type { TRequestTiming } from '@promster/types';
 
-const NS_PER_SEC = 1e9;
+const NS_PER_SEC = BigInt(1e9);
 
-function endMeasurementFrom(start: TRequestTiming) {
-  const [seconds, nanoseconds] = process.hrtime(start);
+function endMeasurementFrom(startTime: TRequestTiming) {
+  const endTime = process.hrtime.bigint();
 
   return {
-    durationS: (seconds * NS_PER_SEC + nanoseconds) / NS_PER_SEC,
+    durationS: Number((endTime - startTime) / NS_PER_SEC),
   };
 }
 

--- a/packages/metrics/src/end-measurement-from/end-measurement-from.ts
+++ b/packages/metrics/src/end-measurement-from/end-measurement-from.ts
@@ -1,12 +1,10 @@
-import type { TRequestTiming } from '@promster/types';
+const NS_PER_SEC = 1e9;
 
-const NS_PER_SEC = BigInt(1e9);
-
-function endMeasurementFrom(startTime: TRequestTiming) {
-  const endTime = process.hrtime.bigint();
+function endMeasurementFrom(start: [number, number]) {
+  const [seconds, nanoseconds] = process.hrtime(start);
 
   return {
-    durationS: Number((endTime - startTime) / NS_PER_SEC),
+    durationS: (seconds * NS_PER_SEC + nanoseconds) / NS_PER_SEC,
   };
 }
 

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -14,8 +14,10 @@ import {
 import { isRunningInKubernetes, skipMetricsInEnvironment } from './environment';
 import { endMeasurementFrom } from './end-measurement-from';
 import { sortLabels } from './sort-labels';
+import { timing } from './timing';
 
 export type { TRequestRecorder } from './create-request-recorder';
+export type { Timing as TPromsterTiming } from './timing';
 
 export {
   Prometheus,
@@ -35,4 +37,5 @@ export {
   skipMetricsInEnvironment,
   endMeasurementFrom,
   sortLabels,
+  timing,
 };

--- a/packages/metrics/src/timing/index.ts
+++ b/packages/metrics/src/timing/index.ts
@@ -1,0 +1,3 @@
+import timing, { Timing } from './timing';
+
+export { timing, Timing };

--- a/packages/metrics/src/timing/timing.spec.js
+++ b/packages/metrics/src/timing/timing.spec.js
@@ -1,0 +1,14 @@
+const { default: timing, Timing } = require('./timing');
+
+describe('timing', () => {
+  it('should return an instance of Timing', () => {
+    expect(timing.start()).toBeInstanceOf(Timing);
+  });
+
+  it('should allow ending timing when started', () => {
+    const requestTiming = timing.start();
+    requestTiming.end();
+
+    expect(requestTiming.value().seconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/metrics/src/timing/timing.ts
+++ b/packages/metrics/src/timing/timing.ts
@@ -1,0 +1,44 @@
+class Timing {
+  static NS_PER_SEC = BigInt(1e9);
+
+  #startTime?: bigint;
+  #endTime?: bigint;
+
+  constructor() {
+    this.reset();
+  }
+
+  value() {
+    const startTime = this.#startTime;
+    const endTime = this.#endTime;
+
+    return {
+      seconds:
+        endTime &&
+        startTime &&
+        Number((endTime - startTime) / Timing.NS_PER_SEC),
+    };
+  }
+
+  reset() {
+    this.#startTime = process.hrtime.bigint();
+    this.#endTime = undefined;
+
+    return this;
+  }
+
+  end() {
+    this.#endTime = process.hrtime.bigint();
+
+    return this;
+  }
+}
+
+const timing = {
+  start() {
+    return new Timing();
+  },
+};
+
+export default timing;
+export { Timing };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,4 +47,4 @@ export type TGraphQlMetrics = {
 
 export type TValueOf<T> = T[keyof T];
 
-export type TRequestTiming = [number, number];
+export type TRequestTiming = bigint;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,5 +46,3 @@ export type TGraphQlMetrics = {
 };
 
 export type TValueOf<T> = T[keyof T];
-
-export type TRequestTiming = bigint;

--- a/readme.md
+++ b/readme.md
@@ -77,8 +77,8 @@
 
 > These packages are a combination of observations and experiences I have had with other exporters which I tried to fix.
 
-1.  🏎 Use `process.hrtime()` for high-resolution real time in metrics in seconds (converting from nanoseconds)
-    - `process.hrtime()` calls libuv's `uv_hrtime`, without system call like `new Date`
+1.  🏎 Use `process.hrtime.bigint()` for high-resolution real time in metrics in seconds (converting from nanoseconds)
+    - `process.hrtime.bigint()` calls libuv's `uv_hrtime`, without system call like `new Date`
 2.  ⚔️ Allow normalization of all pre-defined label values
 3.  🖥 Expose Garbage Collection among other metric of the Node.js process by default
 4.  🚨 Expose a built-in server to expose metrics quickly (on a different port) while also allowing users to integrate with existing servers
@@ -284,7 +284,7 @@ const fetch = request('node-fetch');
 
 const async fetchSomeData = () => {
   const recordRequest = getRequestRecorder();
-  const start = process.hrtime();
+  const start = process.hrtime.bigint();
 
   const data = await fetch('https://another-api.com').then(res => res.json());
 

--- a/readme.md
+++ b/readme.md
@@ -279,16 +279,16 @@ Moreover, both `@promster/hapi` and `@promster/express` expose the request recor
 
 ```js
 // Note that a getter is exposed as the request recorder is only available after initialisation.
-const { getRequestRecorder } = require('@promster/express');
+const { getRequestRecorder, timing } = require('@promster/express');
 const fetch = request('node-fetch');
 
 const async fetchSomeData = () => {
   const recordRequest = getRequestRecorder();
-  const start = process.hrtime.bigint();
+  const requestTiming = timing.start();
 
   const data = await fetch('https://another-api.com').then(res => res.json());
 
-  recordRequest(start, {
+  recordRequest(requestTiming, {
     other: 'label-values'
   });
 


### PR DESCRIPTION
Closes #790

# Summary

Using `process.hrtime.bigint` over only `process.hrtime()`.