### PR TITLE
fix: correct type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,7 +17,7 @@ export type TPromsterOptions = {
   normalizeMethod?: <Q, S>(method: string, context: TContext<Q, S>) => string;
   getLabelValues?: <Q, S>(request: Q, response: S) => TLabelValues;
   detectKubernetes?: boolean;
-  buckets?: [number];
+  buckets?: number[];
   percentiles?: [number];
   skip?: <Q, S>(request: Q, response: S, labels: TLabelValues) => boolean;
   disableGcMetrics?: boolean;


### PR DESCRIPTION
#### Summary

allow more than one number in the buckets-array.

#### Description

unable to do this properly with the corporate proxy at the moment so might not be following guidelines.