### PR TITLE
Use req.route.path for express path detection

### DIFF
--- a/packages/express/src/middleware/middleware.ts
+++ b/packages/express/src/middleware/middleware.ts
@@ -32,7 +32,7 @@ const exposeOnLocals = ({ app, key, value }: TLocaleTarget) => {
   if (app?.locals) app.locals[key] = value;
 };
 
-const extractPath = (req: Request) => req.originalUrl || req.url;
+const extractPath = (req: Request) => req.route.path;
 
 let recordRequest: TRequestRecorder;
 let upMetric: TGcMetrics['up'];


### PR DESCRIPTION
#### Summary

Use req.route.path for express path detection

#### Description

req.route.path is a better choice because it protects from some bad actor scanning your website with example.com/<random_path> and pollutes metrics with useless values

#### Technical debt & future

<!--
  Which technical debt does this PR introduce?
  How do we plan to resolve it?
  What is the next step after this PR?
-->
