### PR TITLE
rename metrics `up`

### DIFF
--- a/.changeset/tame-berries-collect.md
+++ b/.changeset/tame-berries-collect.md
@@ -1,0 +1,11 @@
+---
+'@promster/apollo': major
+'@promster/express': major
+'@promster/fastify': major
+'@promster/hapi': major
+'@promster/marblejs': major
+'@promster/metrics': major
+'@promster/server': major
+---
+
+rename metric up to nodejs_up

--- a/.changeset/tame-berries-collect.md
+++ b/.changeset/tame-berries-collect.md
@@ -8,4 +8,16 @@
 '@promster/server': major
 ---
 
-rename metric up to nodejs_up
+The `up` metric of each server integrating `@promster` has been renamed to `nodejs_up`. This is to avoid a collision with the existing `up` metric [Prometheus uses](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series).
+
+You can still rename this metric to anything you prefer when condfigurating `@promster/express` for instance like this:
+
+```js
+const prometheusMetricsMiddleware = createPrometheusMetricsMiddleware({
+  options: {
+    metricNames: {
+      up: ['service_name_up'],
+    },
+  },
+});
+```

--- a/packages/apollo/src/plugin/plugin.spec.js
+++ b/packages/apollo/src/plugin/plugin.spec.js
@@ -122,7 +122,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/packages/express/src/middleware/middleware.spec.js
+++ b/packages/express/src/middleware/middleware.spec.js
@@ -81,7 +81,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/packages/fastify/src/plugin/plugin.spec.js
+++ b/packages/fastify/src/plugin/plugin.spec.js
@@ -75,7 +75,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/packages/hapi/src/plugin/plugin.spec.js
+++ b/packages/hapi/src/plugin/plugin.spec.js
@@ -72,7 +72,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/packages/marblejs/src/middleware/middleware.spec.js
+++ b/packages/marblejs/src/middleware/middleware.spec.js
@@ -71,7 +71,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/packages/metrics/src/create-gc-metrics/create-gc-metrics.ts
+++ b/packages/metrics/src/create-gc-metrics/create-gc-metrics.ts
@@ -12,7 +12,7 @@ const defaultOptions = {
   labels: [],
   metricPrefix: '',
   metricNames: {
-    up: ['up'],
+    up: ['nodejs_up'],
     countOfGcs: ['nodejs_gc_runs_total'],
     durationOfGc: ['nodejs_gc_pause_seconds_total'],
     reclaimedInGc: ['nodejs_gc_reclaimed_bytes_total'],
@@ -24,7 +24,7 @@ const getMetrics = (options: TDefaultedPromsterOptions) => ({
     (nameOfUpMetric: string) =>
       new Prometheus.Gauge({
         name: `${options.metricPrefix}${nameOfUpMetric}`,
-        help: '1 = up, 0 = not up',
+        help: '1 = nodejs server is up, 0 = nodejs server is not up',
       })
   ),
   countOfGcs: asArray(options.metricNames.countOfGcs).map(

--- a/packages/server/src/server/server.spec.js
+++ b/packages/server/src/server/server.spec.js
@@ -49,7 +49,7 @@ it('should up metric', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: 'up',
+        name: 'nodejs_up',
       }),
     ])
   );

--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Promster has to be setup with your server. Either as an Express middleware of an
 
 ### Garbage Collection
 
-- `up`: an indication if the server is started: either 0 or 1
+- `nodejs_up`: an indication if the nodejs server is started: either 0 (not up) or 1 (up)
 - `nodejs_gc_runs_total`: total garbage collections count
 - `nodejs_gc_pause_seconds_total`: time spent in garbage collection
 - `nodejs_gc_reclaimed_bytes_total`: number of bytes reclaimed by garbage collection


### PR DESCRIPTION
#### Summary

Currently, promster exposes a metrics named `up` as an indication whether nodejs server is up or not.

The name `up` is conflicting with the similarily named metrics `up` automatically generated by prometheus.

I suggest in this PR to rename the promster metric `up` with something else: `nodejs_up`

#### Description

Whenever a Prometheus scrapes a target, it will automatically generate and store a metrics named `up` (among others) : [link to docs](https://prometheus.io/docs/concepts/jobs_instances/#automatically-generated-labels-and-time-series)

In prometheus, this `up` means that prometheus could scrape the target (1) or failed to reach and scrape the target (0).

However in our case, the target (the app using promster to exposes metrics)  also exposes a metric named `up`. It has a different purpose, a different meaning: 1 if nodejs server is up; 0 if not.

This creates a conflict, as prometheus in the end only stores one metric `up`. It creates some rare edge cases issues as well: for instance, an app using promster could (during the shutdown phase for example) exposes up=0, but prometheus can still scrape the metrics so the prometheus' up sample value would be 1. In those cases, prometheus silently record only one `up` and then logs (in debug mode only) the error `Error on ingesting samples with different value but same timestamp`.

#### Technical debt & future

This is a small breaking change. The metrics `up` users will find in their monitoring stack will now be the one autogenerated from prometheus only, while there will be a new additionnal metrics named `nodejs_up`. If your (promql) queries were looking for a `up`, they will need to be changed. This will mostly affect alertrules and dashboards relying on this `up` metrics.