### PR TITLE
refactor: move to supported node-prometheus-gc-stats

### DIFF
--- a/.changeset/great-bugs-rush.md
+++ b/.changeset/great-bugs-rush.md
@@ -1,0 +1,14 @@
+---
+"@promster/metrics": major
+"@promster/types": patch
+---
+
+Replace `@sematext/gc-stats` with `prometheus-gc-stats`.
+
+The latter is better supported and doesn't require any userland install. The module however does not allow to full configuration of metric names. Hence the metric names have changed:
+
+We now expose:
+
+1. nodejs_gc_runs_total: Counts the number of time GC is invoked
+2. nodejs_gc_pause_seconds_total: Time spent in GC in seconds
+3. nodejs_gc_reclaimed_bytes_total: The number of bytes GC has freed

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -38,9 +38,9 @@
   "dependencies": {
     "@promster/types": "^13.0.0",
     "lodash.memoize": "4.1.2",
+    "prometheus-gc-stats": "1.1.0",
     "lodash.once": "4.1.1",
     "merge-options": "3.0.4",
-    "optional": "0.1.4",
     "tslib": "2.6.2",
     "url-value-parser": "2.2.0"
   },
@@ -49,9 +49,6 @@
     "typescript": "5.3.3",
     "@types/node": "20.11.30",
     "@types/lodash.once": "4.1.9"
-  },
-  "optionalDependencies": {
-    "@sematext/gc-stats": "1.5.9"
   },
   "peerDependencies": {
     "prom-client": "13.x.x || 14.x || 15.x"

--- a/packages/metrics/src/client/client.ts
+++ b/packages/metrics/src/client/client.ts
@@ -1,4 +1,5 @@
 import once from 'lodash.once';
+import type { PrometheusContentType } from 'prom-client';
 import * as Prometheus from 'prom-client';
 import { skipMetricsInEnvironment } from '../environment';
 
@@ -9,8 +10,9 @@ const defaultRegister = Prometheus.register;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 interface TClientOptions
-  extends Prometheus.DefaultMetricsCollectorConfiguration {
+  extends Prometheus.DefaultMetricsCollectorConfiguration<PrometheusContentType> {
   detectKubernetes?: boolean;
+  prefix?: string;
 }
 
 const configure = once((options: TClientOptions) => {

--- a/packages/metrics/src/create-gc-metrics/create-gc-metrics.spec.js
+++ b/packages/metrics/src/create-gc-metrics/create-gc-metrics.spec.js
@@ -20,16 +20,4 @@ describe('createGcMetrics', () => {
   it('should have `up` metric', () => {
     expect(metrics).toHaveProperty('up');
   });
-
-  it('should have `countOfGcs` metric', () => {
-    expect(metrics).toHaveProperty('countOfGcs');
-  });
-
-  it('should have `durationOfGc` metric', () => {
-    expect(metrics).toHaveProperty('durationOfGc');
-  });
-
-  it('should have `reclaimedInGc` metric', () => {
-    expect(metrics).toHaveProperty('reclaimedInGc');
-  });
 });

--- a/packages/metrics/src/create-gc-metrics/create-gc-metrics.ts
+++ b/packages/metrics/src/create-gc-metrics/create-gc-metrics.ts
@@ -6,7 +6,6 @@ import {
 import merge from 'merge-options';
 import { configure, Prometheus } from '../client';
 
-const defaultLabels = ['gc_type'];
 const asArray = (maybeArray: Readonly<string[] | string>) =>
   Array.isArray(maybeArray) ? maybeArray : [maybeArray];
 
@@ -16,9 +15,6 @@ const defaultOptions = {
   metricPrefix: '',
   metricNames: {
     up: ['nodejs_up'],
-    countOfGcs: ['nodejs_gc_runs_total'],
-    durationOfGc: ['nodejs_gc_pause_seconds_total'],
-    reclaimedInGc: ['nodejs_gc_reclaimed_bytes_total'],
   },
 };
 
@@ -28,30 +24,6 @@ const getMetrics = (options: TDefaultedPromsterOptions) => ({
       new Prometheus.Gauge({
         name: `${options.metricPrefix}${nameOfUpMetric}`,
         help: '1 = nodejs server is up, 0 = nodejs server is not up',
-      })
-  ),
-  countOfGcs: asArray(options.metricNames.countOfGcs).map(
-    (nameOfCountOfGcsMetric: string) =>
-      new Prometheus.Counter({
-        name: `${options.metricPrefix}${nameOfCountOfGcsMetric}`,
-        help: 'Count of total garbage collections.',
-        labelNames: defaultLabels,
-      })
-  ),
-  durationOfGc: asArray(options.metricNames.durationOfGc).map(
-    (nameOfDurationOfGcMetric: string) =>
-      new Prometheus.Counter({
-        name: `${options.metricPrefix}${nameOfDurationOfGcMetric}`,
-        help: 'Time spent in GC Pause in seconds.',
-        labelNames: defaultLabels,
-      })
-  ),
-  reclaimedInGc: asArray(options.metricNames.reclaimedInGc).map(
-    (nameOfReclaimedInGcMetric: string) =>
-      new Prometheus.Counter({
-        name: `${options.metricPrefix}${nameOfReclaimedInGcMetric}`,
-        help: 'Total number of bytes reclaimed by GC.',
-        labelNames: defaultLabels,
       })
   ),
 });

--- a/packages/metrics/src/create-gc-observer/create-gc-observer.ts
+++ b/packages/metrics/src/create-gc-observer/create-gc-observer.ts
@@ -1,33 +1,12 @@
 import {
   type TOptionalPromsterOptions,
   type TGcMetrics,
-  type TValueOf,
 } from '@promster/types';
 
 import once from 'lodash.once';
 // @ts-expect-error
-import requireOptional from 'optional';
-
-const gc = requireOptional('@sematext/gc-stats');
-
-const gcTypes = {
-  0: 'unknown',
-  1: 'scavenge',
-  2: 'mark_sweep_compact',
-  3: 'scavenge_and_mark_sweep_compact',
-  4: 'incremental_marking',
-  8: 'weak_phantom',
-  15: 'all',
-} as const;
-
-type TGcTypes = TValueOf<typeof gcTypes>;
-type TStats = {
-  gctype: TGcTypes;
-  pause: number;
-  diff: {
-    usedHeapSize: number;
-  };
-};
+import gcStats from 'prometheus-gc-stats';
+import { defaultRegister } from '../client/client';
 
 const defaultOptions = {
   disableGcMetrics: false,
@@ -35,31 +14,11 @@ const defaultOptions = {
 
 const createGcObserver = once(
   (metrics: TGcMetrics, options: TOptionalPromsterOptions) => () => {
-    if (typeof gc !== 'function') {
-      return;
-    }
-
-    if (options.disableGcMetrics) return;
-
-    gc().on('stats', (stats: TStats) => {
-      // @ts-expect-error
-      const gcType: TGcTypes = gcTypes[stats.gctype];
-
-      metrics.countOfGcs.forEach((countOfGcMetricType) => {
-        countOfGcMetricType.labels(gcType).inc();
-      });
-      metrics.durationOfGc.forEach((durationOfGcMetricType) => {
-        durationOfGcMetricType.labels(gcType).inc(stats.pause / 1e9);
-      });
-
-      if (stats.diff.usedHeapSize < 0) {
-        metrics.reclaimedInGc.forEach((reclaimedInGcMetricType) => {
-          reclaimedInGcMetricType
-            .labels(gcType)
-            .inc(stats.diff.usedHeapSize * -1);
-        });
-      }
+    const startGcStats = gcStats(defaultRegister, {
+      prefix: options.metricPrefix,
     });
+
+    startGcStats();
   }
 );
 

--- a/packages/server/src/server/server.spec.js
+++ b/packages/server/src/server/server.spec.js
@@ -66,6 +66,9 @@ it('should expose garbage collection metrics', async () => {
   expect(parsedMetrics).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
+        name: 'nodejs_version_info',
+      }),
+      expect.objectContaining({
         name: 'process_cpu_user_seconds_total',
       }),
       expect.objectContaining({
@@ -84,19 +87,10 @@ it('should expose garbage collection metrics', async () => {
         name: 'nodejs_eventloop_lag_seconds',
       }),
       expect.objectContaining({
-        name: 'nodejs_gc_runs_total',
-      }),
-      expect.objectContaining({
-        name: 'nodejs_gc_duration_seconds',
-      }),
-      expect.objectContaining({
         name: 'nodejs_eventloop_lag_max_seconds',
       }),
       expect.objectContaining({
         name: 'nodejs_eventloop_lag_p50_seconds',
-      }),
-      expect.objectContaining({
-        name: 'nodejs_version_info',
       }),
     ])
   );

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,9 +37,6 @@ export type THttpMetrics = {
 };
 export type TGcMetrics = {
   up: Gauge[];
-  countOfGcs: Counter[];
-  durationOfGc: Counter[];
-  reclaimedInGc: Counter[];
 };
 export type TGraphQlMetrics = {
   graphQlParseDuration?: Histogram[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,19 +286,15 @@ importers:
       merge-options:
         specifier: 3.0.4
         version: 3.0.4
-      optional:
-        specifier: 0.1.4
-        version: 0.1.4
+      prometheus-gc-stats:
+        specifier: 1.1.0
+        version: 1.1.0(prom-client@15.1.0)
       tslib:
         specifier: 2.6.2
         version: 2.6.2
       url-value-parser:
         specifier: 2.2.0
         version: 2.2.0
-    optionalDependencies:
-      '@sematext/gc-stats':
-        specifier: 1.5.9
-        version: 1.5.9
     devDependencies:
       '@types/lodash.once':
         specifier: 4.1.9
@@ -3165,7 +3161,6 @@ packages:
   /@opentelemetry/api@1.7.0:
     resolution: {integrity: sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==}
     engines: {node: '>=8.0.0'}
-    dev: true
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4503,7 +4498,6 @@ packages:
 
   /bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
-    dev: true
 
   /body-parser@1.20.1:
     resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
@@ -8525,7 +8519,21 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.7.0
       tdigest: 0.1.2
-    dev: true
+
+  /prometheus-gc-stats@1.1.0(prom-client@15.1.0):
+    resolution: {integrity: sha512-z2JefryWO0KzgejYHpc/i838P3LjERBzZdnUPYr8LbAOIZ+zkPDRTv1ryer2n09sliODvxea4JcLoYo0+yZApQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      prom-client: '>= 10 <= 15'
+    dependencies:
+      optional: 0.1.4
+      prom-client: 15.1.0
+    optionalDependencies:
+      '@sematext/gc-stats': 1.5.9
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
 
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -9422,7 +9430,6 @@ packages:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
     dependencies:
       bintrees: 1.0.2
-    dev: true
 
   /teeny-request@7.1.1:
     resolution: {integrity: sha512-iwY6rkW5DDGq8hE2YgNQlKbptYpY5Nn2xecjQiNjOXWbKzPGUfmeUBCSQbbr306d7Z7U2N0TPl+/SwYRfua1Dg==}


### PR DESCRIPTION
#### Summary

This removes support for `@sematext/gc-stats` and uses `prometheus-gc-stats` instead.

The names of metrics have changed. Hence a breaking change.