### PR TITLE
feat(undici): add agent metrics

### DIFF
--- a/.changeset/three-squids-prove.md
+++ b/.changeset/three-squids-prove.md
@@ -1,0 +1,5 @@
+---
+"@promster/undici": minor
+---
+
+Adds support for Agent metrics in addition to exposting Pool metrics. Refer to readme for more information.

--- a/packages/undici/package.json
+++ b/packages/undici/package.json
@@ -47,7 +47,7 @@
     "prom-client": "15.1.3",
     "typescript": "5.7.3",
     "parse-prometheus-text-format": "1.1.1",
-    "undici": "7.8.0",
+    "undici": "7.9.0",
     "express": "4.21.2",
     "@promster/server": "workspace:*",
     "@promster/express": "workspace:*"

--- a/packages/undici/src/agent-metrics.ts
+++ b/packages/undici/src/agent-metrics.ts
@@ -1,0 +1,119 @@
+import { Prometheus, defaultRegister } from '@promster/metrics';
+import type {
+  Agent as TUndiciAgent,
+  Dispatcher as TUndiciDispatcher,
+  Pool as TUndiciPool,
+} from 'undici';
+
+type TAgentMetricsExporterOptions = {
+  metricPrefix?: string;
+};
+type TAgentStatsKeys = keyof TUndiciPool.PoolStats;
+
+class ObservedAgents {
+  private agents: TUndiciAgent[];
+
+  constructor(initialAgents?: TUndiciAgent[]) {
+    this.agents = [];
+
+    if (initialAgents) {
+      this.addMany(initialAgents);
+    }
+  }
+
+  add(agent: TUndiciAgent): TUndiciAgent {
+    this.agents.push(agent);
+
+    return agent;
+  }
+
+  addMany(agents: TUndiciAgent[]): void {
+    this.agents.push(...agents);
+  }
+
+  remove(agent: TUndiciAgent): boolean {
+    const index = this.agents.indexOf(agent);
+    if (index !== -1) {
+      this.agents.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+
+  get size(): number {
+    return this.agents.length;
+  }
+
+  [Symbol.iterator](): IterableIterator<TUndiciAgent> {
+    return this.agents.values();
+  }
+}
+
+const observedAgents = new ObservedAgents();
+
+function addObservedAgent(agent: TUndiciAgent) {
+  return observedAgents.add(agent);
+}
+
+const supportedAgentStats: readonly TAgentStatsKeys[] = [
+  'connected',
+  'free',
+  'pending',
+  'queued',
+  'running',
+  'size',
+];
+
+function createAgentMetricsExporter(
+  initialAgents?: TUndiciAgent[],
+  options?: TAgentMetricsExporterOptions
+): void {
+  const metricName = `${options?.metricPrefix ?? ''}nodejs_undici_agent`;
+
+  if (initialAgents) {
+    observedAgents.addMany(initialAgents);
+  }
+
+  new Prometheus.Gauge({
+    name: `${metricName}s_total`,
+    help: 'Number of Undici agents.',
+    registers: [defaultRegister],
+    collect() {
+      this.set(observedAgents.size);
+    },
+  });
+
+  for (const supportedStat of supportedAgentStats) {
+    new Prometheus.Gauge({
+      name: `${metricName}_${supportedStat}`,
+      help: `Statistics for Undici agents ${supportedStat} stat. See https://github.com/nodejs/undici/blob/main/docs/docs/api/Agent.md#agentstats`,
+      labelNames: ['origin'],
+      registers: [defaultRegister],
+      collect() {
+        for (const agent of observedAgents) {
+          // If the agent has made no requests, it will not have stats
+          if (!agent.stats) {
+            continue;
+          }
+
+          for (const [origin, stats] of Object.entries(agent.stats)) {
+            // Client stats do not have free property
+            // @ts-expect-error
+            const statValue = stats[supportedStat];
+
+            if (typeof statValue === 'number' && !Number.isNaN(statValue)) {
+              this.labels(origin).set(statValue);
+            }
+          }
+        }
+      },
+    });
+  }
+}
+
+export {
+  createAgentMetricsExporter,
+  supportedAgentStats,
+  addObservedAgent,
+  type TAgentMetricsExporterOptions,
+};

--- a/packages/undici/src/index.ts
+++ b/packages/undici/src/index.ts
@@ -13,3 +13,9 @@ export {
   observedPoolFactory,
   supportedPoolStats,
 } from './pool-metrics';
+
+export {
+  createAgentMetricsExporter,
+  addObservedAgent,
+  supportedAgentStats,
+} from './agent-metrics';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
       undici:
-        specifier: 7.8.0
-        version: 7.8.0
+        specifier: 7.9.0
+        version: 7.9.0
 
 packages:
 
@@ -3982,8 +3982,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.8.0:
-    resolution: {integrity: sha512-vFv1GA99b7eKO1HG/4RPu2Is3FBTWBrmzqzO0mz+rLxN3yXkE4mqRcb8g8fHxzX4blEysrNZLqg5RbJLqX5buA==}
+  undici@7.9.0:
+    resolution: {integrity: sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==}
     engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
@@ -8367,7 +8367,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.8.0: {}
+  undici@7.9.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,25 @@ const serveMetrics$ = r
 
 ### `@promster/undici`
 
-First you have create the pool metrics exporter
+Depending on the `undici` version used you have to use a pool metrics exporter or can use the agent metric exporter.
+
+### `undici` version `7.9.0` or later
+
+```js
+import { createAgentMetricsExporter } = from "@promster/undici";
+
+createAgentMetricsExporter({ agentA, agentB });
+```
+
+You can then also always add additional agents
+
+```js
+import { addObservedAgent } = from "@promster/undici";
+
+addObservedAgent(agent);
+```
+
+### `undici` version `7.9.0` or before
 
 ```js
 import { createPoolMetricsExporter } = from "@promster/undici";


### PR DESCRIPTION
#### Summary

Adds support for agent metrics. This change is possible with the latest undici release. The pool metrics are kept for backwards compatibility.