### PR TITLE
use «export type *»

### DIFF
--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@apollo/server": "4.10.5",
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "merge-options": "3.0.4",
     "tslib": "2.8.1"
   },
@@ -46,6 +45,7 @@
     "@graphql-tools/schema": "10.0.25",
     "@graphql-tools/utils": "10.9.1",
     "@promster/server": "workspace:*",
+    "@promster/types": "workspace:*",
     "apollo-server": "3.13.0",
     "graphql": "16.11.0",
     "parse-prometheus-text-format": "1.1.1"

--- a/packages/apollo/src/index.ts
+++ b/packages/apollo/src/index.ts
@@ -26,4 +26,4 @@ export {
   timing,
 };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -37,13 +37,13 @@
   ],
   "dependencies": {
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "merge-options": "3.0.4",
     "tslib": "2.8.1"
   },
   "devDependencies": {
     "@promster/server": "workspace:*",
     "@types/express": "4.17.23",
+    "@promster/types": "workspace:*",
     "express": "4.21.2",
     "parse-prometheus-text-format": "1.1.1"
   }

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -28,4 +28,4 @@ export {
   timing,
 };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -38,12 +38,12 @@
   "dependencies": {
     "@promster/metrics": "workspace:*",
     "@promster/server": "workspace:*",
-    "@promster/types": "workspace:*",
     "fastify-plugin": "^4.5.1",
     "merge-options": "3.0.4",
     "parse-prometheus-text-format": "1.1.1"
   },
   "devDependencies": {
+    "@promster/types": "workspace:*",
     "fastify": "4.29.1"
   }
 }

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -28,4 +28,4 @@ export {
   timing,
 };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/hapi/package.json
+++ b/packages/hapi/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "merge-options": "3.0.4",
     "semver": "7.7.2",
     "tslib": "2.8.1"
@@ -46,6 +45,7 @@
     "@hapi/boom": "10.0.1",
     "@hapi/hapi": "21.4.0",
     "@promster/server": "workspace:*",
+    "@promster/types": "workspace:*",
     "@types/hapi__hapi": "21.0.0",
     "@types/semver": "7.7.0",
     "parse-prometheus-text-format": "1.1.1"

--- a/packages/hapi/src/index.ts
+++ b/packages/hapi/src/index.ts
@@ -34,4 +34,4 @@ export {
   timing,
 };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/marblejs/package.json
+++ b/packages/marblejs/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "merge-options": "3.0.4",
     "rxjs": "^7.8.1",
     "tslib": "2.8.1"
@@ -46,6 +45,7 @@
     "@marblejs/core": "4.1.0",
     "@marblejs/http": "4.1.0",
     "@promster/server": "workspace:*",
+    "@promster/types": "workspace:*",
     "fp-ts": "2.16.10",
     "parse-prometheus-text-format": "1.1.1"
   }

--- a/packages/marblejs/src/index.ts
+++ b/packages/marblejs/src/index.ts
@@ -14,7 +14,7 @@ import {
   type TPromsterOptions,
 } from './middleware';
 
-export * from '@promster/types';
+export type * from '@promster/types';
 export type { TPromsterOptions };
 
 export {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -36,7 +36,6 @@
     "prometheus"
   ],
   "dependencies": {
-    "@promster/types": "workspace:*",
     "lodash.memoize": "4.1.2",
     "lodash.once": "4.1.1",
     "merge-options": "3.0.4",
@@ -45,6 +44,7 @@
     "url-value-parser": "2.2.0"
   },
   "devDependencies": {
+    "@promster/types": "workspace:*",
     "@types/lodash.once": "4.1.9",
     "@types/node": "22.14.0",
     "prom-client": "15.1.3",

--- a/packages/metrics/src/index.ts
+++ b/packages/metrics/src/index.ts
@@ -40,4 +40,4 @@ export {
   timing,
 };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,10 +37,10 @@
   ],
   "dependencies": {
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "tslib": "2.8.1"
   },
   "devDependencies": {
+    "@promster/types": "workspace:*",
     "@types/node": "22.14.0",
     "parse-prometheus-text-format": "1.1.1"
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,4 +2,4 @@ import { createServer } from './server';
 
 export { createServer };
 
-export * from '@promster/types';
+export type * from '@promster/types';

--- a/packages/undici/package.json
+++ b/packages/undici/package.json
@@ -38,11 +38,11 @@
   ],
   "dependencies": {
     "@promster/metrics": "workspace:*",
-    "@promster/types": "workspace:*",
     "merge-options": "3.0.4",
     "tslib": "2.6.3"
   },
   "devDependencies": {
+    "@promster/types": "workspace:*",
     "@types/node": "20.19.9",
     "prom-client": "15.1.3",
     "typescript": "5.8.3",


### PR DESCRIPTION
`export type * from "pkg";` was implemented in [Typescript 5](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#support-for-export-type-).

With this change, a project using e.g. `@promster/fastify` with `npm install --omit=dev` in production will omit types, typescript and its dependencies.