### PR TITLE
Honor the diableGcMetrics option for hapi

### DIFF
--- a/.changeset/every-ties-start.md
+++ b/.changeset/every-ties-start.md
@@ -1,0 +1,5 @@
+---
+"@promster/hapi": patch
+---
+
+Honor the diableGcMetrics option for hapi

--- a/packages/hapi/src/plugin/plugin.ts
+++ b/packages/hapi/src/plugin/plugin.ts
@@ -120,7 +120,7 @@ const createPlugin = (
   recordRequest = createRequestRecorder(httpMetrics, allDefaultedOptions);
   upMetric = gcMetrics?.up;
 
-  if (!shouldSkipMetricsByEnvironment) {
+  if (!shouldSkipMetricsByEnvironment && !allDefaultedOptions.disableGcMetrics) {
     observeGc();
   }
 

--- a/packages/hapi/src/plugin/plugin.ts
+++ b/packages/hapi/src/plugin/plugin.ts
@@ -120,7 +120,10 @@ const createPlugin = (
   recordRequest = createRequestRecorder(httpMetrics, allDefaultedOptions);
   upMetric = gcMetrics?.up;
 
-  if (!shouldSkipMetricsByEnvironment && !allDefaultedOptions.disableGcMetrics) {
+  if (
+    !shouldSkipMetricsByEnvironment &&
+    !allDefaultedOptions.disableGcMetrics
+  ) {
     observeGc();
   }
 


### PR DESCRIPTION


#### Summary

The hapi plugin was calling observeGc() completely ignoring the disableGcMetrics option.

#### Description

The option is now taken into account.

#### Technical debt & future

Other packages are impacted by this bug. Only apollo correctly supported this option.