### PR TITLE
chore(deps): update pnpm to 11.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,5 @@
     "npm": ">=11",
     "pnpm": ">=11"
   },
-  "packageManager": "pnpm@11.9.0"
+  "packageManager": "pnpm@11.24.0"
 }


### PR DESCRIPTION
#### Summary

Bumps `packageManager` from `pnpm@11.9.0` to `pnpm@11.24.0`, a jump of 17 releases. One line changed, no lockfile churn.

#### Description

pnpm 11.24.0 still writes `lockfileVersion: '9.0'`, and a full install against the committed lockfile reports `Already up to date`. So despite the size of the version jump, the diff is a single line.

This is the follow-up to #1598 and only lands safely because of it. The `pnpm/setup@v1` action installed pnpm through `@pnpm/exe` on npm, and that artifact is broken for 11.13.0 and newer — CI would have failed here with `This: not found` (exit 127). `pnpm/setup@v2` downloads the self-contained release binary from GitHub releases instead, and verifies the install by running `pnpm --version` against the requested version.

Verified locally with pnpm 11.24.0 driving every step:

- `install --no-frozen-lockfile` → no lockfile diff
- `install --frozen-lockfile` → passes, which is what CI runs
- `build`, `test`, `check-types`, `lint`, `format:check` → all exit 0
- `manypkg check` → workspaces valid
- `check-exports` → no problems found

`engines.pnpm` stays at `>=11` and needs no change.

#### Technical debt & future

None introduced. Remaining from #697:

- **Orange:** `oxfmt` 0.59 → 0.65 (0.x formatter, may reflow the repo), `oxlint` 1.74 → 1.80 (`categories.correctness: error`, so new rules can fail CI), `@graphql-tools/utils` 11 → 12, `fastify-plugin` 5 → 6 (runtime dep of `@promster/fastify`, needs a changeset), lock file maintenance.
- **Red:** `prom-client` deprecation → `@prometheus-io/client`, `graphql` 17 blocked by `@apollo/server`'s `^16.11.0` peer, and the Changesets v3 migration.