### PR TITLE
chore(deps): update fastify-plugin to v6 and @graphql-tools/utils to v12

### DIFF
--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+"@promster/fastify": patch
+"@promster/apollo": patch
+---
+
+fix(deps): update fastify-plugin to v6 and @graphql-tools/utils to v12

--- a/packages/apollo/package.json
+++ b/packages/apollo/package.json
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@graphql-tools/schema": "10.1.0",
-    "@graphql-tools/utils": "11.2.2",
+    "@graphql-tools/utils": "12.0.0",
     "@promster/server": "workspace:*",
     "@promster/tsconfig": "workspace:*",
     "@promster/tsdown-config": "workspace:*",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@promster/metrics": "workspace:*",
     "@promster/server": "workspace:*",
-    "fastify-plugin": "^5.1.0",
+    "fastify-plugin": "^6.0.0",
     "merge-options": "3.0.4",
     "parse-prometheus-text-format": "1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0(graphql@16.14.2)
       '@graphql-tools/utils':
-        specifier: 11.2.2
-        version: 11.2.2(graphql@16.14.2)
+        specifier: 12.0.0
+        version: 12.0.0(graphql@16.14.2)
       '@promster/server':
         specifier: workspace:*
         version: link:../server
@@ -1248,12 +1248,6 @@ packages:
 
   '@graphql-tools/schema@10.1.0':
     resolution: {integrity: sha512-wao48XQnfY631s3jXoNrhEHvCI8mlKXmIuWrR7F6zAdv92VuSOfHoq9P9KL2EnUMgBUnaStnByOx9Mn6RieWDg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/utils@11.2.2':
-    resolution: {integrity: sha512-Do2A/t6ayqOma8m7PvpYMsCBswL+NB35BQSng4GWSBqafL2/BnfAZy/NSENPwV721Rm2fG0BHETFC0+FJJZmLw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -5268,14 +5262,6 @@ snapshots:
     dependencies:
       '@graphql-tools/merge': 9.2.3(graphql@16.14.2)
       '@graphql-tools/utils': 12.0.0(graphql@16.14.2)
-      graphql: 16.14.2
-      tslib: 2.8.1
-
-  '@graphql-tools/utils@11.2.2(graphql@16.14.2)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
       graphql: 16.14.2
       tslib: 2.8.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,8 +164,8 @@ importers:
         specifier: workspace:*
         version: link:../server
       fastify-plugin:
-        specifier: ^5.1.0
-        version: 5.1.0
+        specifier: ^6.0.0
+        version: 6.0.0
       merge-options:
         specifier: 3.0.4
         version: 3.0.4
@@ -2806,8 +2806,8 @@ packages:
   fast-uri@4.1.0:
     resolution: {integrity: sha512-ZodJ2cRiLVWGi9IgPb3mbgSqM4CD3LexCHkuv0FfBXHJI1ADfucTD06m6clO2Cy5RZYsw/SiCVl/dyrFI/SYWA==}
 
-  fastify-plugin@5.1.0:
-    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+  fastify-plugin@6.0.0:
+    resolution: {integrity: sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==}
 
   fastify@5.12.1:
     resolution: {integrity: sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==}
@@ -6558,7 +6558,7 @@ snapshots:
 
   fast-uri@4.1.0: {}
 
-  fastify-plugin@5.1.0: {}
+  fastify-plugin@6.0.0: {}
 
   fastify@5.12.1:
     dependencies:


### PR DESCRIPTION
#### Summary

The two remaining major bumps from the #697 orange group. Grouped into one PR because they share a lockfile, but each is a standalone commit and either can be dropped without touching the other.

#### Description

**`fix(deps): update fastify-plugin to v6`** — the only consumer-visible change here. `fastify-plugin` is a runtime `dependencies` entry of `@promster/fastify`, so widening `^5.1.0` to `^6.0.0` reaches everyone installing the package.

Both of v6's breaking changes miss this codebase, verified rather than assumed:

| Breaking change | Impact here |
|---|---|
| Entry points moved: `plugin.js` → `index.js`, `types/plugin.d.ts` → `types/index.d.ts` | None. Only deep imports resolve through those paths; `plugin.ts` imports the bare specifier `fastify-plugin`. |
| Deprecated `PluginOptions` interface removed in favour of `PluginMetadata` | None. Neither name appears anywhere in `packages/`. |

**`chore(deps): update @graphql-tools/utils to v12`** — test-only. It is a devDependency of `@promster/apollo` and never reaches the published bundle. v12 keeps its graphql peer at `^14 || ^15 || ^16 || ^17`, so the pinned `graphql@16.14.2` stays valid and the install resolves with no peer warnings.

`graphql` itself stays on 16 — it is still blocked by `@apollo/server@5.5.1`'s `^16.11.0` peer.

Verified locally after each commit: `build`, `test`, `check-types`, `lint` and `format:check` all pass, with `fastify-plugin@6.0.0` and `@graphql-tools/utils@12.0.0` confirmed as the resolved versions.

#### Technical debt & future

A changeset is included. `fastify-plugin` shipping to consumers is what makes it necessary; the `fixed: [["@promster/*"]]` group then expands the patch across all eleven workspace packages.

This closes out the orange group apart from lock file maintenance, which is best run last, once #1600 and #1601 have landed.

Remaining red items from #697, all still needing a decision rather than a bump:

- **`prom-client` is deprecated** in favour of `@prometheus-io/client` (now `prometheus/client_js`, at 0.16.0). It is a peer dependency of `@promster/metrics`, `@promster/types` and `@promster/undici`. Small code surface, but the peer range redesign plus a major across every package is the real cost.
- **`graphql` 17** blocked by Apollo Server's peer, as above.
- **Changesets v3**, where private packages are no longer versioned by default — which affects the `fixed` lockstep with `@promster/tsconfig` and `@promster/tsdown-config`.