### PR TITLE
fix(types): spell out label name type on metric types

### DIFF
--- a/.changeset/lucky-pugs-invent.md
+++ b/.changeset/lucky-pugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@promster/types": patch
+---
+
+Spell out the label name type on the exported metric types

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -24,22 +24,29 @@ export type TOptionalPromsterOptions = {
 };
 export type TDefaultedPromsterOptions = DeepRequired<TOptionalPromsterOptions>;
 
+// NOTE:
+//   The label name type is spelled out as `<string>` rather than left to the
+//   default. `prom-client` defaults it to `string`, so today both spellings
+//   mean the same thing, but its successor `@prometheus-io/client` defaults it
+//   to `NoLabelNameType`, which is `never`. Under that default a bare
+//   `Counter` is a metric that accepts no labels at all, which would silently
+//   break every consumer calling `.inc({ method: 'GET' })` on these.
 export type THttpMetrics = {
-  httpRequestDurationPerPercentileInSeconds?: Summary[];
-  httpRequestDurationInSeconds?: Histogram[];
-  httpRequestsTotal?: Counter[];
-  httpRequestContentLengthInBytes?: Histogram[];
-  httpResponseContentLengthInBytes?: Histogram[];
+  httpRequestDurationPerPercentileInSeconds?: Summary<string>[];
+  httpRequestDurationInSeconds?: Histogram<string>[];
+  httpRequestsTotal?: Counter<string>[];
+  httpRequestContentLengthInBytes?: Histogram<string>[];
+  httpResponseContentLengthInBytes?: Histogram<string>[];
 };
 export type TGcMetrics = {
-  up: Gauge[];
+  up: Gauge<string>[];
 };
 export type TGraphQlMetrics = {
-  graphQlParseDuration?: Histogram[];
-  graphQlValidationDuration?: Histogram[];
-  graphQlResolveFieldDuration?: Histogram[];
-  graphQlRequestDuration?: Histogram[];
-  graphQlErrorsTotal?: Counter[];
+  graphQlParseDuration?: Histogram<string>[];
+  graphQlValidationDuration?: Histogram<string>[];
+  graphQlResolveFieldDuration?: Histogram<string>[];
+  graphQlRequestDuration?: Histogram<string>[];
+  graphQlErrorsTotal?: Counter<string>[];
 };
 
 export type TValueOf<T> = T[keyof T];


### PR DESCRIPTION
#### Summary

`@promster/types` exported bare `Counter`, `Gauge`, `Histogram` and `Summary`, relying on the default of their label-name generic. This names it explicitly as `<string>`. No behaviour change today.

#### Description

`prom-client` and its successor disagree about that default:

```ts
// prom-client 15.1.3
export class Counter<T extends string = string>

// @prometheus-io/client 0.16.0
export class Counter<T extends string = NoLabelNameType>   // type NoLabelNameType = never
```

And the successor's label helper turns that into a hard constraint:

```ts
type LabelValues<T extends string> = T extends NoLabelNameType
  ? Partial<Record<string, never>>
  : Partial<Record<T, string | number>>;
```

So under `@prometheus-io/client` a bare `Counter` is a metric that accepts **no labels at all**. Every consumer calling `.inc({ method: 'GET' })` against `THttpMetrics['httpRequestsTotal']` would stop type-checking — silently, with no runtime signal and nothing a smoke test would catch.

`@promster/metrics` is unaffected; it already writes `Histogram<string>` explicitly in `create-metric.ts`. Only the types package relied on the default, and only there does it reach the public API.

The real point is not the successor specifically. Depending on a default that two otherwise compatible versions of the same library define differently is the fragility. Naming it removes the dependency on either.

#### Verification

`build`, `check-types`, `test`, `lint` and `format:check` all pass. The emitted `packages/types/dist/index.d.ts` carries the explicit generics and is otherwise unchanged, so the published contract is identical under `prom-client` 15.

#### Technical debt & future

This is deliberately the *only* preparatory work being done for the `prom-client` deprecation. The migration itself is parked — see the note on #697. Three things block it, none of which this PR addresses:

1. **`@chainsafe/prometheus-gc-stats`** declares `peerDependencies: { "prom-client": ">= 10" }` and is a runtime dependency of `@promster/metrics`. Switching the peer leaves consumers with an unmet peer unless they install both clients.
2. **`@prometheus-io/client` is one day old** — published 2026-08-24, 409 weekly downloads against prom-client's ~9M, and explicitly pre-1.0 at `0.16.0`.
3. **It requires Node `^22 || ^24 || >=26`**, against the `>=20` these packages currently declare.